### PR TITLE
Architecture rework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,17 +26,18 @@ set(falafels_files
     src/node/roles/aggregator/aggregator.hpp
     src/node/roles/aggregator/asynchronous_aggregator.cpp
     src/node/roles/aggregator/asynchronous_aggregator.hpp
-    src/node/roles/aggregator/hierarchical_aggregator.cpp
-    src/node/roles/aggregator/hierarchical_aggregator.hpp
+    # src/node/roles/aggregator/hierarchical_aggregator.cpp
+    # src/node/roles/aggregator/hierarchical_aggregator.hpp
     src/node/roles/aggregator/simple_aggregator.cpp
     src/node/roles/aggregator/simple_aggregator.hpp
 
-    src/node/roles/proxy/proxy.cpp
-    src/node/roles/proxy/proxy.hpp
+    # src/node/roles/proxy/proxy.cpp
+    # src/node/roles/proxy/proxy.hpp
 
     src/node/roles/trainer/trainer.cpp
     src/node/roles/trainer/trainer.hpp
 
+    src/node/roles/role.cpp
     src/node/roles/role.hpp
     
     src/node/node.cpp

--- a/src/config_loader.cpp
+++ b/src/config_loader.cpp
@@ -9,10 +9,10 @@
 
 #include "node/network_managers/nm.hpp"
 #include "node/roles/aggregator/asynchronous_aggregator.hpp"
-#include "node/roles/aggregator/hierarchical_aggregator.hpp"
+// #include "node/roles/aggregator/hierarchical_aggregator.hpp"
 #include "node/roles/aggregator/simple_aggregator.hpp"
 #include "node/roles/trainer/trainer.hpp"
-#include "node/roles/proxy/proxy.hpp"
+// #include "node/roles/proxy/proxy.hpp"
 #include "node/network_managers/star_nm.hpp"
 #include "node/network_managers/ring_nm.hpp"
 #include "config_loader.hpp"
@@ -93,7 +93,7 @@ unique_ptr<Aggregator> create_aggregator(xml_node *role_elem, unordered_map<stri
     else if (strcmp(aggregator_type, "hierarchical") == 0)
     {
         XBT_INFO("With role: Hierarchical");
-        aggregator = make_unique<HierarchicalAggregator>(args);
+        // aggregator = make_unique<HierarchicalAggregator>(args);
     }
 
     return aggregator; 
@@ -196,7 +196,7 @@ void create_nodes(unordered_map<node_name, Node*> *nodes_map, xml_node *nodes_el
         }
 
         // Set boostrap nodes
-        nodes_map->at(name)->get_role()->get_network_manager()->set_bootstrap_nodes(bootstrap_nodes); 
+        nodes_map->at(name)->set_bootstrap_nodes(bootstrap_nodes); 
     }
 }
 

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -14,7 +14,7 @@ public:
     /** Simulated model size that will be sent through the network as a packet. */
     inline static uint64_t MODEL_SIZE_BYTES = 2000;
 
-    /** Number of flops for aggregating one local model with the global one. */
+    /** Number of flops for aggregating ONE local model with the global one. */
     inline static double GLOBAL_MODEL_AGGREGATING_FLOPS = 1000000.0;
 
     /** Number of flops for training a local model. */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@ XBT_LOG_NEW_DEFAULT_CATEGORY(s4u_main, "Messages specific for this example");
 
 void node_runner(Node *node)
 {
-    XBT_INFO("Init node: %s", node->get_role()->get_network_manager()->get_my_node_name().c_str());
+    XBT_INFO("Init node: %s", node->get_node_info().name.c_str());
     node->run();
     delete node;
 
@@ -25,36 +25,34 @@ void node_runner(Node *node)
 
 int main(int argc, char* argv[])
 {
+    simgrid::s4u::Engine e(&argc, argv);
+
     // Initializing host and link energy plugins
     sg_host_energy_plugin_init();
     sg_link_energy_plugin_init();
 
-    auto e = simgrid::s4u::Engine::get_instance();
-    // simgrid::s4u::Engine e(&argc, argv);
-    
     xbt_assert(argc > 2, "Usage: %s platform_file deployment_file\n", argv[0]);
 
     /* Load the platform description and then deploy the application */
-    e->load_platform(argv[1]);
+    e.load_platform(argv[1]);
 
     // Using our own deployment function instead of simgrid's one
     // e.load_deployment(argv[2]);
 
-    auto nodes_map = load_config(argv[2], e); 
+    auto nodes_map = load_config(argv[2], &e); 
 
     for (auto [name, node] : *nodes_map)
     {
         XBT_INFO("Creating actor '%s'", name.c_str());
-        auto actor = simgrid::s4u::Actor::create(name, e->host_by_name(name), &node_runner, node); 
+        auto actor = simgrid::s4u::Actor::create(name, e.host_by_name(name), &node_runner, node); 
     }
 
     /* Run the simulation */
-    e->run();
+    e.run();
 
     DOTGenerator::get_instance().generate_state_files();
 
     delete nodes_map;
-    delete e;
 
     XBT_INFO("Simulation is over");
 

--- a/src/node/network_managers/nm.cpp
+++ b/src/node/network_managers/nm.cpp
@@ -1,6 +1,7 @@
 #include "nm.hpp"
 #include <algorithm>
 #include <format>
+#include <memory>
 #include <optional>
 #include <simgrid/Exception.hpp>
 #include <simgrid/forward.h>
@@ -21,13 +22,42 @@ XBT_LOG_NEW_DEFAULT_CATEGORY(s4u_network_manager, "Messages specific for this ex
 
 NetworkManager::NetworkManager()
 {
-    this->pending_async_comms = new simgrid::s4u::ActivitySet();
+    this->pending_async_put = new simgrid::s4u::ActivitySet();
+
+    // Set first get_async
+    this->pending_async_get = this->mailbox->get_async();
+
+    this->registration_requests = new vector<Packet::RegistrationRequest>();
 }
 
 NetworkManager::~NetworkManager()
 {
     delete this->bootstrap_nodes;
-    delete this->pending_async_comms;
+    delete this->pending_async_put;
+    delete this->registration_requests;
+}
+
+optional<shared_ptr<Packet>> NetworkManager::get_to_be_sent_packet()
+{
+    if (this->to_be_sent_packets->empty())
+        return nullopt;
+
+    auto p = std::move(this->to_be_sent_packets->front());
+    this->to_be_sent_packets->pop();
+    return p;
+}
+
+void NetworkManager::put_received_packet(unique_ptr<Packet> packet)
+{
+    this->received_packets->push(std::move(packet));
+}
+
+void NetworkManager::set_queues(
+    shared_ptr<queue<unique_ptr<Packet>>> received, 
+    shared_ptr<queue<shared_ptr<Packet>>> to_be_sent)
+{
+    this->received_packets = received;
+    this->to_be_sent_packets = to_be_sent;
 }
 
 void NetworkManager::set_bootstrap_nodes(vector<NodeInfo> *nodes)
@@ -35,50 +65,105 @@ void NetworkManager::set_bootstrap_nodes(vector<NodeInfo> *nodes)
     this->bootstrap_nodes = nodes;
 }
 
-void NetworkManager::send(shared_ptr<Packet> packet, node_name dst, const optional<double> &timeout)
+void NetworkManager::run()
 {
-    auto p_clone          = packet->clone();
-    p_clone->src          = this->get_my_node_name();
-    p_clone->dst          = dst;
-    auto receiver_mailbox = simgrid::s4u::Mailbox::by_name(p_clone->dst); 
-
-    if (timeout)
+    switch (this->state)
     {
-        try 
-        {
-            DOTGenerator::get_instance().add_to_state(
-                simgrid::s4u::Engine::get_instance()->get_clock(), 
-                std::format("{} -> {} [label=\"{} (timeout: {})\", style=dotted];", 
-                            p_clone->src, p_clone->dst, p_clone->get_op_name(), *timeout)
-            );
+        case INITIALIZING:
+            switch (this->my_node_info.role)
+            {
+                case NodeRole::Trainer:
+                    this->send_registration_request();
+                    this->state = WAITING_REGISTRATION_CONFIRMATION;
+                    break;
+                case NodeRole::Aggregator:
+                    this->state = WAITING_REGISTRATION_REQUEST;
+                    break;
+            }
+            break;
+        case WAITING_REGISTRATION_CONFIRMATION:
+            if (auto packet = this->try_get())
+            {
+                if (auto *confirmation = get_if<Packet::RegistrationConfirmation>(&(*packet)->op))
+                {
+                    this->handle_registration_confirmation(*confirmation);
+                    this->state = RUNNING;
+                }
+            }
+            break;
+        case WAITING_REGISTRATION_REQUEST:
+            if (!this->time)
+                *this->time = simgrid::s4u::Engine::get_instance()->get_clock();
 
-            XBT_INFO("%s ---%s(%lu)--> %s (timeout: %f)", p_clone->src.c_str(), p_clone->get_op_name(), p_clone->id, p_clone->dst.c_str(), *timeout);
-            receiver_mailbox->put(p_clone, p_clone->get_packet_size(), *timeout);
-        } 
-        catch (simgrid::TimeoutException) 
-        {
-            XBT_INFO("Timeout, couldn't send message from %s to %s", this->get_my_node_name().c_str(), dst.c_str());
-            delete p_clone;
-        }
-    }
-    else
-    {
-        DOTGenerator::get_instance().add_to_state(
-            simgrid::s4u::Engine::get_instance()->get_clock(), 
-            std::format("{} -> {} [label=\"{}\", style=dotted];", 
-                        p_clone->src, p_clone->dst, p_clone->get_op_name())
-        );
+            if (auto packet = this->try_get())
+            {
+                if (auto *request = get_if<Packet::RegistrationRequest>(&(*packet)->op))
+                {
+                    this->registration_requests->push_back(*request);
+                }
 
-        XBT_INFO("%s ---%s(%lu)--> %s", p_clone->src.c_str(), p_clone->get_op_name(), p_clone->id, p_clone->dst.c_str());
-        receiver_mailbox->put(p_clone, p_clone->get_packet_size());
+            }
+
+            // At some point, stop listening for registration requests and end this state
+            if (simgrid::s4u::Engine::get_instance()->get_clock() - *this->time > 2)
+            {
+                this->handle_registration_requests();
+                this->state = RUNNING;
+            }
+            break;
+        case RUNNING:
+            if (auto packet = this->try_get())
+            {
+                this->route_packet(std::move(*packet));
+            }
+
+            if (auto p = this->get_to_be_sent_packet())
+            {
+                this->send_packet(*p);
+            }
+            break;
     }
 }
 
-void NetworkManager::send_async(shared_ptr<Packet> packet, node_name dst)
+optional<unique_ptr<Packet>> NetworkManager::try_get()
 {
-    auto p_clone          = packet->clone();
-    p_clone->src          = this->get_my_node_name();
-    p_clone->dst          = dst;
+    if (this->pending_async_get->test())
+    {
+        auto p = this->pending_async_get->get_data<Packet>();
+        this->pending_async_get = this->mailbox->get_async();
+
+        auto unique_packet = make_unique<Packet>(*p);
+        delete p;
+        return unique_packet;
+    }
+    else
+    {
+        return nullopt;
+    }
+}
+
+void NetworkManager::send_packet(shared_ptr<Packet> p)
+{
+    if (p->broadcast)
+    {
+        this->broadcast(p);
+    }
+    else
+    {
+        this->send_async(p);
+    }
+}
+
+void NetworkManager::send_async(shared_ptr<Packet> packet, bool is_redirected)
+{
+    auto p_clone = packet->clone();
+    p_clone->src = this->get_my_node_name();
+    p_clone->dst = packet->dst;
+
+    // Only write original source when sending packets created by the current node.
+    if (!is_redirected)
+        p_clone->original_src = this->get_my_node_name();
+
     auto receiver_mailbox = simgrid::s4u::Mailbox::by_name(p_clone->dst);
 
     DOTGenerator::get_instance().add_to_state(
@@ -90,50 +175,27 @@ void NetworkManager::send_async(shared_ptr<Packet> packet, node_name dst)
 
     auto comm =  receiver_mailbox->put_async(p_clone, p_clone->get_packet_size());
     
-    this->pending_async_comms->push(comm);
+    this->pending_async_put->push(comm);
 }
 
-unique_ptr<Packet> NetworkManager::get(const optional<double> &timeout)
-{
-    unique_ptr<Packet> p;
-
-    if (timeout)
-    {
-        p = this->mailbox->get_unique<Packet>(*timeout);
-    }
-    else 
-    {
-        p = this->mailbox->get_unique<Packet>();
-    }
-
-    DOTGenerator::get_instance().add_to_state(
-        simgrid::s4u::Engine::get_instance()->get_clock(), 
-        std::format("{} -> {} [label=\"{}\"];", 
-                    p->src, p->dst, p->get_op_name())
-    );
-
-    XBT_INFO("%s <--%s(%lu)--- %s", this->get_my_node_name().c_str(), p->get_op_name(), p->id, p->src.c_str());
-    return p;
-}
-
-void NetworkManager::wait_last_comms(const optional<double> &timeout)
-{
-    if (!timeout)
-    {
-        this->pending_async_comms->wait_all();
-    }
-    else
-    {
-        try
-        {
-            // Wait finish pending comms before exiting with timeout in case of double send
-            this->pending_async_comms->wait_all_for(*timeout);
-        } 
-        catch (simgrid::TimeoutException)
-        {
-            XBT_INFO("Timeout");
-        }
-    }
-
-    this->pending_async_comms->clear();
-}
+// void NetworkManager::wait_last_comms(const optional<double> &timeout)
+// {
+//     if (!timeout)
+//     {
+//         this->pending_async_comms->wait_all();
+//     }
+//     else
+//     {
+//         try
+//         {
+//             // Wait finish pending comms before exiting with timeout in case of double send
+//             this->pending_async_comms->wait_all_for(*timeout);
+//         } 
+//         catch (simgrid::TimeoutException)
+//         {
+//             XBT_INFO("Timeout");
+//         }
+//     }
+// 
+//     this->pending_async_comms->clear();
+// }

--- a/src/node/network_managers/nm.cpp
+++ b/src/node/network_managers/nm.cpp
@@ -144,7 +144,10 @@ bool NetworkManager::run()
             }
             break;
         case KILLING:
-            this->pending_async_put->wait_all();
+            // TBH implementing kill isn't very interesting and will not play a lot in electric consumption.
+            // It might be a loss of time.....
+            this->wait_last_comms(1);
+            // this->pending_async_put->wait_all();
             return false;
     }
     return true;
@@ -207,24 +210,24 @@ void NetworkManager::send_async(shared_ptr<Packet> packet, bool is_redirected)
     this->pending_async_put->push(comm);
 }
 
-// void NetworkManager::wait_last_comms(const optional<double> &timeout)
-// {
-//     if (!timeout)
-//     {
-//         this->pending_async_comms->wait_all();
-//     }
-//     else
-//     {
-//         try
-//         {
-//             // Wait finish pending comms before exiting with timeout in case of double send
-//             this->pending_async_comms->wait_all_for(*timeout);
-//         } 
-//         catch (simgrid::TimeoutException)
-//         {
-//             XBT_INFO("Timeout");
-//         }
-//     }
-// 
-//     this->pending_async_comms->clear();
-// }
+void NetworkManager::wait_last_comms(const optional<double> &timeout)
+{
+    if (!timeout)
+    {
+        this->pending_async_put->wait_all();
+    }
+    else
+    {
+        try
+        {
+            // Wait finish pending comms before exiting with timeout in case of double send
+            this->pending_async_put->wait_all_for(*timeout);
+        } 
+        catch (simgrid::TimeoutException)
+        {
+            XBT_INFO("Timeout");
+        }
+    }
+
+    this->pending_async_put->clear();
+}

--- a/src/node/network_managers/nm.cpp
+++ b/src/node/network_managers/nm.cpp
@@ -126,6 +126,7 @@ bool NetworkManager::run()
         case RUNNING:
             if (auto packet = this->try_get())
             {
+                // Case where we receive Kill
                 if (auto *kill = get_if<Packet::KillTrainer>(&(*packet)->op))
                 {
                     this->state = KILLING;
@@ -135,6 +136,7 @@ bool NetworkManager::run()
 
             if (auto p = this->get_to_be_sent_packet())
             {
+                // Case where we send kill to someone else
                 if (auto *kill = get_if<Packet::KillTrainer>(&(*p)->op))
                 {
                     this->state = KILLING;
@@ -146,7 +148,9 @@ bool NetworkManager::run()
         case KILLING:
             // TBH implementing kill isn't very interesting and will not play a lot in electric consumption.
             // It might be a loss of time.....
-            this->wait_last_comms(1);
+            this->pending_async_put->clear();
+            //this->pending_async_put->wait_all_for(2);
+            // this->wait_last_comms(1);
             // this->pending_async_put->wait_all();
             return false;
     }

--- a/src/node/network_managers/nm.hpp
+++ b/src/node/network_managers/nm.hpp
@@ -12,23 +12,36 @@
 #include <simgrid/s4u/Mailbox.hpp>
 #include <tuple>
 #include <unordered_map>
+#include <variant>
 #include <vector>
 #include "../../protocol.hpp"
 
 class NetworkManager 
 {
-protected:
+public:
+    struct NodeConnected
+    {
+    };
+
+    /** Event thrown when our node is acting as a bootstrap node, indicating that all nodes were connected to us */
+    struct ClusterConnected
+    {
+        uint16_t number_client_connected;
+    };
+
+    using Event = std::variant<NodeConnected, ClusterConnected>;
+protected: 
     using State = enum
     {
         INITIALIZING,
         WAITING_REGISTRATION_REQUEST,
         WAITING_REGISTRATION_CONFIRMATION,
         RUNNING,
+        KILLING,
     };
 
-    State state;
+    State state = INITIALIZING;
 
-    simgrid::s4u::Mailbox *mailbox;
     std::vector<NodeInfo> *bootstrap_nodes;
     NodeInfo my_node_info;
 
@@ -36,13 +49,18 @@ protected:
     std::optional<double> time;
 
     /** get to be used for inherited classes of NetworkManager */
-    std::unique_ptr<Packet> get(const std::optional<double> &timeout=std::nullopt);
+    // std::unique_ptr<Packet> get(const std::optional<double> &timeout=std::nullopt);
 
     std::optional<std::shared_ptr<Packet>> get_to_be_sent_packet();
     void put_received_packet(std::unique_ptr<Packet> packet);
-public: 
-    NetworkManager();
-    void run();
+    void put_nm_event(Event e);
+
+    simgrid::s4u::ActivitySet *pending_async_put;
+    simgrid::s4u::CommPtr pending_async_get;
+public:  
+    simgrid::s4u::Mailbox *mailbox;
+    NetworkManager(NodeInfo node_info);
+    bool run();
 
     uint16_t get_nb_connected_clients() { return this->registration_requests->size(); }
 
@@ -57,24 +75,24 @@ public:
     void set_bootstrap_nodes(std::vector<NodeInfo> *nodes);
 
     void set_queues(std::shared_ptr<std::queue<std::unique_ptr<Packet>>> received, 
-                    std::shared_ptr<std::queue<std::shared_ptr<Packet>>> to_be_sent);
+                    std::shared_ptr<std::queue<std::shared_ptr<Packet>>> to_be_sent,
+                    std::shared_ptr<std::queue<std::unique_ptr<Event>>> nm_events);
 
     /* --------- Methods to be redefined by children classes --------- */
     virtual ~NetworkManager();
     virtual void handle_registration_requests() = 0;
     virtual void send_registration_request() = 0;
     virtual void handle_registration_confirmation(const Packet::RegistrationConfirmation &confirmation) = 0;
-    virtual void broadcast(std::shared_ptr<Packet>, const std::optional<double> &timeout=std::nullopt) = 0;
+    virtual void broadcast(std::shared_ptr<Packet>) = 0;
 
     /** This function decides wether it should give the packet to the (local) Role (by sending it through received_packets vector)
         or if it should redirect it to another Node. */
     virtual void route_packet(std::unique_ptr<Packet> packet) = 0;
 private:
-    simgrid::s4u::ActivitySet *pending_async_put;
-    simgrid::s4u::CommPtr pending_async_get;
 
     std::shared_ptr<std::queue<std::unique_ptr<Packet>>> received_packets;
     std::shared_ptr<std::queue<std::shared_ptr<Packet>>> to_be_sent_packets;
+    std::shared_ptr<std::queue<std::unique_ptr<Event>>> nm_events;
     std::optional<std::unique_ptr<Packet>> try_get();
 };
 

--- a/src/node/network_managers/nm.hpp
+++ b/src/node/network_managers/nm.hpp
@@ -6,30 +6,49 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <queue>
 #include <simgrid/forward.h>
+#include <simgrid/s4u/Activity.hpp>
 #include <simgrid/s4u/Mailbox.hpp>
 #include <tuple>
 #include <unordered_map>
 #include <vector>
 #include "../../protocol.hpp"
 
-using FilterNode = std::function<bool(NodeInfo*)>;
-
 class NetworkManager 
 {
 protected:
+    using State = enum
+    {
+        INITIALIZING,
+        WAITING_REGISTRATION_REQUEST,
+        WAITING_REGISTRATION_CONFIRMATION,
+        RUNNING,
+    };
+
+    State state;
+
     simgrid::s4u::Mailbox *mailbox;
     std::vector<NodeInfo> *bootstrap_nodes;
     NodeInfo my_node_info;
 
+    std::vector<Packet::RegistrationRequest> *registration_requests;
+    std::optional<double> time;
+
     /** get to be used for inherited classes of NetworkManager */
     std::unique_ptr<Packet> get(const std::optional<double> &timeout=std::nullopt);
-public:
+
+    std::optional<std::shared_ptr<Packet>> get_to_be_sent_packet();
+    void put_received_packet(std::unique_ptr<Packet> packet);
+public: 
     NetworkManager();
+    void run();
 
-    void send(std::shared_ptr<Packet>, node_name dst, const std::optional<double> &timeout=std::nullopt);
+    uint16_t get_nb_connected_clients() { return this->registration_requests->size(); }
 
-    void send_async(std::shared_ptr<Packet>, node_name);
+    void send_packet(std::shared_ptr<Packet> p);
+    void send_async(std::shared_ptr<Packet> p, bool is_redirected=false);
+
     void wait_last_comms(const std::optional<double> &timeout=std::nullopt);
 
     std::vector<NodeInfo> *get_bootstrap_nodes() { return this->bootstrap_nodes; }
@@ -37,30 +56,26 @@ public:
     NodeInfo get_my_node_info() { return this->my_node_info; }
     void set_bootstrap_nodes(std::vector<NodeInfo> *nodes);
 
+    void set_queues(std::shared_ptr<std::queue<std::unique_ptr<Packet>>> received, 
+                    std::shared_ptr<std::queue<std::shared_ptr<Packet>>> to_be_sent);
+
     /* --------- Methods to be redefined by children classes --------- */
     virtual ~NetworkManager();
-    virtual uint16_t handle_registration_requests() = 0;
+    virtual void handle_registration_requests() = 0;
     virtual void send_registration_request() = 0;
-    virtual void broadcast(std::shared_ptr<Packet>, FilterNode, const std::optional<double> &timeout=std::nullopt) = 0;
+    virtual void handle_registration_confirmation(const Packet::RegistrationConfirmation &confirmation) = 0;
+    virtual void broadcast(std::shared_ptr<Packet>, const std::optional<double> &timeout=std::nullopt) = 0;
 
-    /** get to be used by roles that will be override by the specific NetworkManager */
-    virtual std::unique_ptr<Packet> get_packet(const std::optional<double> &timeout=std::nullopt) = 0;
+    /** This function decides wether it should give the packet to the (local) Role (by sending it through received_packets vector)
+        or if it should redirect it to another Node. */
+    virtual void route_packet(std::unique_ptr<Packet> packet) = 0;
 private:
-    simgrid::s4u::ActivitySet *pending_async_comms;
+    simgrid::s4u::ActivitySet *pending_async_put;
+    simgrid::s4u::CommPtr pending_async_get;
+
+    std::shared_ptr<std::queue<std::unique_ptr<Packet>>> received_packets;
+    std::shared_ptr<std::queue<std::shared_ptr<Packet>>> to_be_sent_packets;
+    std::optional<std::unique_ptr<Packet>> try_get();
 };
-
-namespace Filters {
-    static bool trainers(NodeInfo *node_info)
-    {
-        return node_info->role == NodeRole::Trainer;
-    }
-
-    static bool trainers_and_aggregators(NodeInfo *node_info)
-    {
-        return node_info->role == NodeRole::Trainer || 
-               node_info->role == NodeRole::Aggregator;
-    }
-}
-
 
 #endif // !FALAFELS_NETWORK_MANAGER_HPP

--- a/src/node/network_managers/ring_nm.cpp
+++ b/src/node/network_managers/ring_nm.cpp
@@ -24,15 +24,15 @@ RingNetworkManager::RingNetworkManager(NodeInfo node_info)
     // Initializing our mailbox
     this->mailbox = simgrid::s4u::Mailbox::by_name(node_info.name);
 
-    this->received_packets = new vector<packet_id>();
+    this->received_packet_ids = new vector<packet_id>();
 }
 
 RingNetworkManager::~RingNetworkManager()
 {
-    delete this->received_packets;
+    delete this->received_packet_ids;
 };
 
-uint16_t RingNetworkManager::handle_registration_requests()
+void RingNetworkManager::handle_registration_requests()
 {
     xbt_assert(this->my_node_info.role == NodeRole::Aggregator);
  
@@ -41,52 +41,30 @@ uint16_t RingNetworkManager::handle_registration_requests()
         std::format("{} [label=\"{}\", color=green]", this->my_node_info.name, this->my_node_info.name)
     );
 
-    auto node_list_tmp = vector<NodeInfo>();
-    
-    unique_ptr<Packet> p;
- 
-    // ---------- Wait for registrations ----------
-    while (true) 
-    {
-        try 
-        {
-            p = this->get(Constants::REGISTRATION_TIMEOUT);
-        }
-        catch (simgrid::TimeoutException)
-        {
-            break;
-        }
-
-        if (auto *reg_req = get_if<Packet::RegistrationRequest>(&p->op))
-        {
-            node_list_tmp.push_back(reg_req->node_to_register); 
-        }
-    }
-
     NodeInfo left_n;
     NodeInfo right_n;
 
     // ---------- Create connections and send them ----------
-    for (int i = 0; i < node_list_tmp.size(); i++)
+    for (int i = 0; i < this->registration_requests->size(); i++)
     {
         // Handle edges -> link to the current node to close the ring
         if (i == 0)
         {
             left_n = this->my_node_info;
-            right_n = node_list_tmp.at(i + 1);
-            this->right_node = node_list_tmp.at(i);
+            right_n = this->registration_requests->at(i + 1).node_to_register;
+            this->right_node = this->registration_requests->at(i).node_to_register;
         }
-        else if (i == node_list_tmp.size() - 1) 
+        else if (i == this->registration_requests->size() - 1) 
         {
-            left_n = node_list_tmp.at(i - 1);
+            left_n = this->registration_requests->at(i - 1).node_to_register;
             right_n = this->my_node_info;
-            this->left_node = node_list_tmp.at(i);
+            this->left_node = this->registration_requests->at(i).node_to_register;
         }
         // Normal case we take i-1 and i+1 as neigbours
         else 
         {
-            left_n = node_list_tmp.at(i - 1);
-            right_n = node_list_tmp.at(i + 1);
+            left_n = this->registration_requests->at(i - 1).node_to_register;
+            right_n = this->registration_requests->at(i + 1).node_to_register;
         } 
 
         auto neigbours = vector<NodeInfo>();
@@ -95,13 +73,13 @@ uint16_t RingNetworkManager::handle_registration_requests()
 
         auto res_p = make_shared<Packet>(Packet(
             this->get_my_node_name(), 
-            node_list_tmp.at(i).name, // Sent the packt to the current node
+            this->registration_requests->at(i).node_to_register.name, // Sent the packt to the current node
             Packet::RegistrationConfirmation(
                 make_shared<vector<NodeInfo>>(neigbours)
             )
         ));
 
-        this->send(res_p, node_list_tmp.at(i).name);
+        this->send_async(res_p);
     } 
 
     DOTGenerator::get_instance().add_to_cluster(
@@ -113,9 +91,6 @@ uint16_t RingNetworkManager::handle_registration_requests()
         std::format("cluster-{}", this->my_node_info.name),
         std::format("{} -> {} [color=green]", this->my_node_info.name, this->right_node.name)
     );
-
-    // Return the number of nodes that have been registered
-    return node_list_tmp.size();
 }
 
 void RingNetworkManager::send_registration_request()
@@ -133,95 +108,82 @@ void RingNetworkManager::send_registration_request()
     ));
 
     // Send the request
-    this->send(p, bootstrap_node.name);
+    this->send_async(p);
+}
 
-    unique_ptr<Packet> response;
+void RingNetworkManager::handle_registration_confirmation(const Packet::RegistrationConfirmation &confirmation)
+{
+    XBT_INFO("Succesfully registered");
 
-    // Wait for confirmation 
-    while (true) 
+    auto bootstrap_node = this->bootstrap_nodes->at(0);
+
+    this->left_node = confirmation.node_list->at(0);
+    this->right_node = confirmation.node_list->at(1);
+
+    DOTGenerator::get_instance().add_to_cluster(
+        std::format("cluster-{}", bootstrap_node.name),
+        std::format("{} [label=\"{}\", color=yellow]", this->my_node_info.name, this->my_node_info.name)
+    );
+
+    DOTGenerator::get_instance().add_to_cluster(
+        std::format("cluster-{}", bootstrap_node.name),
+        std::format("{} -> {} [color=green]", this->my_node_info.name, this->left_node.name)
+    );
+
+    DOTGenerator::get_instance().add_to_cluster(
+        std::format("cluster-{}", bootstrap_node.name),
+        std::format("{} -> {} [color=green]", this->my_node_info.name, this->right_node.name)
+    );
+}
+
+void RingNetworkManager::route_packet(std::unique_ptr<Packet> packet)
+{
+    // Check that the packet haven't been already received
+    if(!this->is_duplicated(packet))
     {
-        response = this->get();
-
-        if (auto *reg_conf = get_if<Packet::RegistrationConfirmation>(&response->op))
+        // if the packet has broadcast enabled or if dst is not for the current node
+        if (packet->broadcast || packet->final_dst != this->get_my_node_name())
         {
-            XBT_INFO("Succesfully registered");
-            this->left_node = reg_conf->node_list->at(0);
-            this->right_node = reg_conf->node_list->at(1);
-
-            DOTGenerator::get_instance().add_to_cluster(
-                std::format("cluster-{}", bootstrap_node.name),
-                std::format("{} [label=\"{}\", color=yellow]", this->my_node_info.name, this->my_node_info.name)
-            );
-
-            DOTGenerator::get_instance().add_to_cluster(
-                std::format("cluster-{}", bootstrap_node.name),
-                std::format("{} -> {} [color=green]", this->my_node_info.name, this->left_node.name)
-            );
-
-            DOTGenerator::get_instance().add_to_cluster(
-                std::format("cluster-{}", bootstrap_node.name),
-                std::format("{} -> {} [color=green]", this->my_node_info.name, this->right_node.name)
-            );
-           
-            break;
+            this->redirect(packet);
         }
+        // else route the packet to the local Role
+        else
+        {
+            this->put_received_packet(std::move(packet));
+        }
+
+        // Add to received packets
+        this->received_packet_ids->push_back(packet->id);
+    }
+    else 
+    {
+        XBT_INFO("Discarding packet %lu: duplicate", packet->id);
     }
 }
 
-void RingNetworkManager::broadcast(shared_ptr<Packet> packet, FilterNode filter, const optional<double> &timeout) 
+void RingNetworkManager::broadcast(shared_ptr<Packet> packet) 
 {
     uint16_t res = 0;
 
     // Send to left node
-    if (filter(&this->left_node))
+    if ((*packet->filter)(&this->left_node))
     {
-        this->send(packet, this->left_node.name, timeout);
+        this->send_async(packet);
         res++;
     }
 
     // Send to right node
-    if (filter(&this->right_node))
+    if ((*packet->filter)(&this->right_node))
     {
-        this->send(packet, this->right_node.name, timeout);
+        this->send_async(packet);
         res++;
     }
 }
 
 bool RingNetworkManager::is_duplicated(std::unique_ptr<Packet> &packet)
 {
-    auto r = this->received_packets;
+    auto r = this->received_packet_ids;
     return find(r->begin(), r->end(), packet->id) != r->end();
-}
-
-unique_ptr<Packet> RingNetworkManager::get_packet(const optional<double> &timeout)
-{
-    unique_ptr<Packet> p;
-    bool cond = true;
- 
-    while (cond)
-    {
-        p = this->get(timeout);
- 
-        // Check that the packet haven't been already received
-        if(!this->is_duplicated(p))
-        {
-            // if the packet has broadcast enabled or if dst is not for the current node
-            if (p->final_dst == "BROADCAST" || p->final_dst != this->get_my_node_name())
-            {
-                this->redirect(p);
-            }
-
-            // Add to received packets
-            this->received_packets->push_back(p->id);
-            cond = false;
-        }
-        else 
-        {
-            XBT_INFO("Discarding packet %lu: duplicate", p->id);
-        }
-    }
- 
-    return p;
 }
 
 void RingNetworkManager::redirect(unique_ptr<Packet> &p)
@@ -240,7 +202,10 @@ void RingNetworkManager::redirect(unique_ptr<Packet> &p)
         // Send to the left 
         dst = this->left_node.name;
     }
+
+    new_p->dst = dst;
     
     // Note that the final dest stays the same.
-    this->send_async(new_p, dst);
+    // We specify is_redirected to true to prevent the orginal src from being overwritten.
+    this->send_async(new_p, true);
 }

--- a/src/node/network_managers/ring_nm.hpp
+++ b/src/node/network_managers/ring_nm.hpp
@@ -13,7 +13,7 @@ class RingNetworkManager : public NetworkManager
 private:
     NodeInfo left_node;
     NodeInfo right_node;
-    std::vector<packet_id> *received_packets;
+    std::vector<packet_id> *received_packet_ids;
 
     void redirect(std::unique_ptr<Packet>&);
 
@@ -21,11 +21,15 @@ private:
 public:
     RingNetworkManager(NodeInfo);
     ~RingNetworkManager();
-    uint16_t handle_registration_requests();
+
+    void run();
+    void handle_registration_requests();
     void send_registration_request();
+    void handle_registration_confirmation(const Packet::RegistrationConfirmation &confirmation);
 
     std::unique_ptr<Packet> get_packet(const std::optional<double> &timeout=std::nullopt);
-    void broadcast(std::shared_ptr<Packet>, FilterNode, const std::optional<double> &timeout=std::nullopt);
+    void broadcast(std::shared_ptr<Packet>);
+    void route_packet(std::unique_ptr<Packet> packet);
 
     void set_bootstrap_nodes(std::vector<NodeInfo*> *nodes);
 };

--- a/src/node/network_managers/ring_nm.hpp
+++ b/src/node/network_managers/ring_nm.hpp
@@ -27,11 +27,8 @@ public:
     void send_registration_request();
     void handle_registration_confirmation(const Packet::RegistrationConfirmation &confirmation);
 
-    std::unique_ptr<Packet> get_packet(const std::optional<double> &timeout=std::nullopt);
-    void broadcast(std::shared_ptr<Packet>);
     void route_packet(std::unique_ptr<Packet> packet);
-
-    void set_bootstrap_nodes(std::vector<NodeInfo*> *nodes);
+    void broadcast(std::shared_ptr<Packet>);
 };
 
 #endif // !FALAFELS_DECENTRALIZED_NM_HPP

--- a/src/node/network_managers/star_nm.hpp
+++ b/src/node/network_managers/star_nm.hpp
@@ -21,8 +21,6 @@ public:
     void handle_registration_confirmation(const Packet::RegistrationConfirmation &confirmation);
 
     void route_packet(std::unique_ptr<Packet> packet);
-
-    std::unique_ptr<Packet> get_packet(const std::optional<double> &timeout=std::nullopt);
     void broadcast(std::shared_ptr<Packet>);
 };
 

--- a/src/node/network_managers/star_nm.hpp
+++ b/src/node/network_managers/star_nm.hpp
@@ -14,11 +14,16 @@ private:
 public:
     StarNetworkManager(NodeInfo);
     ~StarNetworkManager();
-    uint16_t handle_registration_requests();
+    
+    void run();
+    void handle_registration_requests();
     void send_registration_request();
+    void handle_registration_confirmation(const Packet::RegistrationConfirmation &confirmation);
+
+    void route_packet(std::unique_ptr<Packet> packet);
 
     std::unique_ptr<Packet> get_packet(const std::optional<double> &timeout=std::nullopt);
-    void broadcast(std::shared_ptr<Packet>, FilterNode, const std::optional<double> &timeout=std::nullopt);
+    void broadcast(std::shared_ptr<Packet>);
 };
 
 #endif // !FALAFELS_CENTRALIZED_NM_HPP

--- a/src/node/node.cpp
+++ b/src/node/node.cpp
@@ -1,4 +1,6 @@
 #include "node.hpp"
+#include "network_managers/nm.hpp"
+#include <memory>
 #include <xbt/log.h>
 
 using namespace std;
@@ -8,17 +10,35 @@ XBT_LOG_NEW_DEFAULT_CATEGORY(s4u_node, "Messages specific for this example");
 Node::Node(unique_ptr<Role> r, unique_ptr<NetworkManager> nm)
 {
     this->role = std::move(r);
-    this->role->set_network_manager(std::move(nm));
+    this->network_manager = std::move(nm);
+
+    auto received_packets = make_shared<queue<unique_ptr<Packet>>>();
+    auto to_be_sent_packets = make_shared<queue<shared_ptr<Packet>>>();
+
+    this->role->set_queues(received_packets, to_be_sent_packets);
+    this->network_manager->set_queues(received_packets, to_be_sent_packets);
 }
 
 Node::~Node()
 {
 }
 
+
+void Node::run()
+{
+    while(true)
+    {
+        // break when the role has been killed
+        if(!this->role->run())
+            break;
+
+        this->network_manager->run();
+    }
+}
+
 NodeInfo Node::get_node_info()
 { 
-    // Instanciate and return NodeInfo struct
-    return this->role->get_network_manager()->get_my_node_info();
+    return this->network_manager->get_my_node_info();
 }
 
 // TODO: fix later

--- a/src/node/node.cpp
+++ b/src/node/node.cpp
@@ -14,9 +14,10 @@ Node::Node(unique_ptr<Role> r, unique_ptr<NetworkManager> nm)
 
     auto received_packets = make_shared<queue<unique_ptr<Packet>>>();
     auto to_be_sent_packets = make_shared<queue<shared_ptr<Packet>>>();
+    auto nm_events = make_shared<queue<unique_ptr<NetworkManager::Event>>>();
 
-    this->role->set_queues(received_packets, to_be_sent_packets);
-    this->network_manager->set_queues(received_packets, to_be_sent_packets);
+    this->role->set_queues(received_packets, to_be_sent_packets, nm_events);
+    this->network_manager->set_queues(received_packets, to_be_sent_packets, nm_events);
 }
 
 Node::~Node()
@@ -28,17 +29,26 @@ void Node::run()
 {
     while(true)
     {
-        // break when the role has been killed
-        if(!this->role->run())
-            break;
+        this->role->run();
 
-        this->network_manager->run();
+        if (!this->network_manager->run())
+            break;
     }
 }
 
 NodeInfo Node::get_node_info()
 { 
     return this->network_manager->get_my_node_info();
+}
+
+NetworkManager *Node::get_network_manager()
+{
+    return this->network_manager.get();
+}
+
+void Node::set_bootstrap_nodes(std::vector<NodeInfo> *nodes)
+{
+    this->network_manager->set_bootstrap_nodes(nodes);
 }
 
 // TODO: fix later

--- a/src/node/node.hpp
+++ b/src/node/node.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <simgrid/s4u/Actor.hpp>
 #include <simgrid/s4u/Engine.hpp>
+#include <vector>
 #include <xbt/log.h>
 #include "roles/role.hpp"
 
@@ -17,12 +18,12 @@
  * - We want to support multiple networking algoritms in order to work with centralized, decentralized and semi-decentralized Federated Learning.
  * 
  * Thus, a node is constituted of a Role and a NetworkManager.
- * The NetworkManager is actually stored in the Role because this last need it... though we might want to change that later by sharing the NetworkManager's reference.
  */
 class Node
 {
 private:
     std::unique_ptr<Role> role;
+    std::unique_ptr<NetworkManager> network_manager; 
 public:
     /**
      * Node constructor
@@ -39,9 +40,9 @@ public:
 
     /**
      * Main function to execute the Node's behaviour.
-     * Call the run function of the associated role of the node.
+     * Call the run function of the Role and NetworkManager(s).
      */
-    void run() { this->role->run(); }
+    void run();
 
     /**
      * Set the Node's Role.
@@ -56,7 +57,7 @@ public:
     Role *get_role() { return role.get(); }
 
     /**
-     * Allocate a NodeInfo struct representing Node's information.
+     * Return a NodeInfo struct representing Node's information.
      * @return NodeInfo*.
      */
     NodeInfo get_node_info();

--- a/src/node/node.hpp
+++ b/src/node/node.hpp
@@ -44,6 +44,11 @@ public:
      */
     void run();
 
+    NetworkManager *get_network_manager();
+
+
+    void set_bootstrap_nodes(std::vector<NodeInfo> *nodes);
+
     /**
      * Set the Node's Role.
      * @param r New Role for the current Node.

--- a/src/node/roles/aggregator/aggregator.cpp
+++ b/src/node/roles/aggregator/aggregator.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <xbt/log.h>
 
 #include "aggregator.hpp"
@@ -5,16 +6,25 @@
 
 XBT_LOG_NEW_DEFAULT_CATEGORY(s4u_aggregator, "Messages specific for this example");
 
-/**
- * Simulate the aggregation execution by multiplying the number of models to aggregate
- * by a constant value indicating the number of flops for one model aggregation.
+/** 
+ * Launch the aggregating activity or test if the current one has finished.
+ * Returns true when aggregation is finished.
  */
-void Aggregator::aggregate(uint64_t number_models)
+bool Aggregator::aggregate() 
 {
-    double flops = Constants::GLOBAL_MODEL_AGGREGATING_FLOPS * number_models;
-    XBT_INFO("Starting aggregation with flops value: %f", flops);
-    simgrid::s4u::this_actor::execute(flops);
-    this->number_aggregated_model += number_models;
+    // if aggregating activity doesn't exists
+    if (this->aggregating_activity == nullptr)
+    {
+        /** Simulate the aggregation execution by multiplying the number of models to aggregate
+            by a constant value indicating the number of flops for one model aggregation. */
+        double flops = Constants::GLOBAL_MODEL_AGGREGATING_FLOPS * this->number_local_models;
+        XBT_INFO("Starting aggregation with flops value: %f", flops);
+
+        this->aggregating_activity = simgrid::s4u::this_actor::exec_async(flops);
+        this->number_aggregated_model += this->number_local_models;
+    }
+
+    return this->aggregating_activity->test(); 
 }
 
 void Aggregator::print_end_report() 

--- a/src/node/roles/aggregator/aggregator.cpp
+++ b/src/node/roles/aggregator/aggregator.cpp
@@ -45,3 +45,28 @@ void Aggregator::print_end_report()
     XBT_INFO("Number of client that were training: %u", this->number_client_training);
     XBT_INFO("Number of global epochs done: %u", this->number_global_epochs);
 }
+
+/* Sends the global model to every trainers */
+void Aggregator::send_global_model()
+{
+    this->put_to_be_sent_packet(
+        Packet(
+            // Send global model with broadcast because we specify a filter instead of a dst
+            Filters::trainers_and_aggregators,
+            Packet::SendGlobalModel(
+                this->number_local_epochs
+            )
+        )
+    );
+}
+
+void Aggregator::send_kills()
+{
+    this->put_to_be_sent_packet(
+        Packet(
+            // Send kills with broadcast
+            Filters::trainers_and_aggregators,
+            Packet::KillTrainer()
+        )
+    );
+}

--- a/src/node/roles/aggregator/aggregator.cpp
+++ b/src/node/roles/aggregator/aggregator.cpp
@@ -1,4 +1,4 @@
-#include <cstdint>
+#include <xbt/asserts.h>
 #include <xbt/log.h>
 
 #include "aggregator.hpp"
@@ -21,17 +21,27 @@ bool Aggregator::aggregate()
         XBT_INFO("Starting aggregation with flops value: %f", flops);
 
         this->aggregating_activity = simgrid::s4u::this_actor::exec_async(flops);
-        this->number_aggregated_model += this->number_local_models;
+        this->number_aggregated_models += this->number_local_models;
     }
 
-    return this->aggregating_activity->test(); 
+    if (this->aggregating_activity->test())
+    {
+        this->aggregating_activity = nullptr;
+        return true;
+    }
+    else
+    {
+        return false; 
+    }
 }
 
 void Aggregator::print_end_report() 
 {
-    this->number_global_epochs = this->number_aggregated_model / this->number_client_training;
+    xbt_assert(this->number_client_training > 0, "Cannot print end report because the Aggregator had 0 or less client training.");
 
-    XBT_INFO("Number of model aggregated: %lu", this->number_aggregated_model);
+    this->number_global_epochs = this->number_aggregated_models / this->number_client_training;
+
+    XBT_INFO("Number of model aggregated: %lu", this->number_aggregated_models);
     XBT_INFO("Number of client that were training: %u", this->number_client_training);
     XBT_INFO("Number of global epochs done: %u", this->number_global_epochs);
 }

--- a/src/node/roles/aggregator/aggregator.hpp
+++ b/src/node/roles/aggregator/aggregator.hpp
@@ -4,17 +4,20 @@
 
 #include "../role.hpp"
 #include <cstdint>
+#include <simgrid/forward.h>
+#include <simgrid/s4u/Exec.hpp>
 
 class Aggregator : public Role 
 {
 protected:
     using State = enum
     {
+        INITIALIZING,
         WAITING_LOCAL_MODELS,
         AGGREGATING,
     };
 
-    State state;
+    State state = INITIALIZING;
 
     /** Value indicating the number of local epochs that the aggregator will ask the trainers to do. */
     uint8_t number_local_epochs = 3;
@@ -23,7 +26,7 @@ protected:
     uint16_t number_global_epochs = 0;
 
     /** Number of local model aggregated, used to compute the global number of epochs. */
-    uint64_t number_aggregated_model = 0;
+    uint64_t number_aggregated_models = 0;
 
     /** The actual number of trainers */
     uint16_t number_client_training = 0;
@@ -41,7 +44,7 @@ protected:
 public:
     Aggregator() {}
     virtual ~Aggregator() {}
-    virtual bool run() = 0;
+    virtual void run() = 0;
     NodeRole get_role_type() { return NodeRole::Aggregator; };
 };
 

--- a/src/node/roles/aggregator/aggregator.hpp
+++ b/src/node/roles/aggregator/aggregator.hpp
@@ -9,6 +9,8 @@
 
 class Aggregator : public Role 
 {
+private:
+    simgrid::s4u::ExecPtr training_activity;
 protected:
     using State = enum
     {
@@ -45,6 +47,9 @@ public:
     Aggregator() {}
     virtual ~Aggregator() {}
     virtual void run() = 0;
+
+    void send_global_model();
+    void send_kills();
     NodeRole get_role_type() { return NodeRole::Aggregator; };
 };
 

--- a/src/node/roles/aggregator/aggregator.hpp
+++ b/src/node/roles/aggregator/aggregator.hpp
@@ -8,6 +8,14 @@
 class Aggregator : public Role 
 {
 protected:
+    using State = enum
+    {
+        WAITING_LOCAL_MODELS,
+        AGGREGATING,
+    };
+
+    State state;
+
     /** Value indicating the number of local epochs that the aggregator will ask the trainers to do. */
     uint8_t number_local_epochs = 3;
 
@@ -20,12 +28,20 @@ protected:
     /** The actual number of trainers */
     uint16_t number_client_training = 0;
 
-    void aggregate(uint64_t number_models);
+    /** Number of the local models collected at a moment in time */
+    uint64_t number_local_models = 0;    
+
+    simgrid::s4u::ExecPtr aggregating_activity = nullptr;
+
+    /** Time when the aggregator has been initialized */
+    double initialization_time;
+
+    bool aggregate();
     void print_end_report();
 public:
     Aggregator() {}
     virtual ~Aggregator() {}
-    virtual void run() = 0;
+    virtual bool run() = 0;
     NodeRole get_role_type() { return NodeRole::Aggregator; };
 };
 

--- a/src/node/roles/aggregator/asynchronous_aggregator.cpp
+++ b/src/node/roles/aggregator/asynchronous_aggregator.cpp
@@ -43,6 +43,7 @@ void AsynchronousAggregator::run()
         this->send_kills();
         this->print_end_report();
         this->still_has_activities = false;
+        return;
     }
 
     switch (this->state)

--- a/src/node/roles/aggregator/asynchronous_aggregator.hpp
+++ b/src/node/roles/aggregator/asynchronous_aggregator.hpp
@@ -11,10 +11,10 @@ private:
     /** Value between 0.0 and 1.0 indicating the proportion of local models needed before initializing an aggregation round */
     float proportion_threshold = 0.5;
 
-    void send_global_model(node_name dst, node_name final_dst);
-    std::tuple<node_name, node_name> wait_local_model();
-    void send_kills();
-    void broadcast_global_model();
+    node_name src_save;
+    node_name original_src_save;
+
+    void send_global_model_to(node_name dst, node_name final_dst);
 public:
     AsynchronousAggregator(std::unordered_map<std::string, std::string> *args);
     ~AsynchronousAggregator() {};

--- a/src/node/roles/aggregator/simple_aggregator.cpp
+++ b/src/node/roles/aggregator/simple_aggregator.cpp
@@ -77,29 +77,3 @@ void SimpleAggregator::run()
             break;
     }
 }
-
-
-/* Sends the global model to every trainers */
-void SimpleAggregator::send_global_model()
-{
-    this->put_to_be_sent_packet(
-        Packet(
-            // Send global model with broadcast because we specify a filter instead of a dst
-            Filters::trainers_and_aggregators,
-            Packet::SendGlobalModel(
-                this->number_local_epochs
-            )
-        )
-    );
-}
-
-void SimpleAggregator::send_kills()
-{
-    this->put_to_be_sent_packet(
-        Packet(
-            // Send kills with broadcast
-            Filters::trainers_and_aggregators,
-            Packet::KillTrainer()
-        )
-    );
-}

--- a/src/node/roles/aggregator/simple_aggregator.cpp
+++ b/src/node/roles/aggregator/simple_aggregator.cpp
@@ -17,12 +17,6 @@ XBT_LOG_NEW_DEFAULT_CATEGORY(s4u_simple_aggregator, "Messages specific for this 
 SimpleAggregator::SimpleAggregator(std::unordered_map<std::string, std::string> *args)
 {
     this->initialization_time = simgrid::s4u::Engine::get_instance()->get_clock();
-    // No arguments yet
-    this->args = args;
-}
-
-SimpleAggregator::~SimpleAggregator()
-{
     delete args;
 }
 

--- a/src/node/roles/aggregator/simple_aggregator.cpp
+++ b/src/node/roles/aggregator/simple_aggregator.cpp
@@ -6,6 +6,7 @@
 
 #include "simple_aggregator.hpp"
 #include "../../../protocol.hpp"
+#include "aggregator.hpp"
 
 using namespace std;
 
@@ -13,6 +14,7 @@ XBT_LOG_NEW_DEFAULT_CATEGORY(s4u_simple_aggregator, "Messages specific for this 
 
 SimpleAggregator::SimpleAggregator(std::unordered_map<std::string, std::string> *args)
 {
+    this->initialization_time = simgrid::s4u::Engine::get_instance()->get_clock();
     // No arguments yet
     this->args = args;
 }
@@ -22,75 +24,71 @@ SimpleAggregator::~SimpleAggregator()
     delete args;
 }
 
-static bool trainer_filter(NodeInfo *node_info)
+bool SimpleAggregator::run()
 {
-    return node_info->role == NodeRole::Trainer;
-}
+    // SET THIS
+    this->number_client_training = NULL; // TODO
 
-void SimpleAggregator::run()
-{
-    // Wait for the trainers to register.
-    this->number_client_training = 
-        this->get_network_manager()->handle_registration_requests();
-
-    auto current_sim_time = simgrid::s4u::Engine::get_instance()->get_clock();
-
-    while (simgrid::s4u::Engine::get_instance()->get_clock() < current_sim_time + Constants::DURATION_TRAINING_PHASE)
+    // Stop aggregating and send kills to the trainers
+    if (simgrid::s4u::Engine::get_instance()->get_clock() > this->initialization_time + Constants::DURATION_TRAINING_PHASE)
     {
-        this->send_global_model();
-        uint64_t number_local_models = this->wait_local_models();
-        this->aggregate(number_local_models);
-    } 
+        this->send_kills();
+        this->print_end_report();
+        return false;
+    }
 
-    this->send_kills();
+    switch (this->state)
+    {
+        case WAITING_LOCAL_MODELS:
+            if (auto packet = this->get_received_packet())
+            {
+                if (auto *send_local = get_if<Packet::SendLocalModel>(&(*packet)->op))
+                {
+                    this->number_local_models += 1;
+                    XBT_INFO("nb local models: %lu", this->number_local_models);
 
-    this->print_end_report();
+                    if (this->number_local_models >= this->number_client_training)
+                    {
+                        this->state = AGGREGATING;
+                    }
+                }
+            }
+            break;
+        case AGGREGATING:
+            if (this->aggregate())
+            {
+                this->number_local_models = 0;
+                this->send_global_model();
+                this->state = WAITING_LOCAL_MODELS;
+            }
+            break;
+    }
+
+    return true;
 }
 
 
-/* Sends the global model to every start_nodes */
+/* Sends the global model to every trainers */
 void SimpleAggregator::send_global_model()
 {
+    // Send global model with broadcast
     auto p = make_shared<Packet>(Packet(
-        this->get_network_manager()->get_my_node_name(), "BROADCAST",
+        Filters::trainers_and_aggregators,
         Packet::SendGlobalModel(
             this->number_local_epochs
         )
     ));
 
-    this->get_network_manager()->broadcast(p, Filters::trainers_and_aggregators);
-}
-
-uint64_t SimpleAggregator::wait_local_models()
-{
-    uint64_t number_local_models = 0;
-    auto nm                      = this->get_network_manager();
-    std::unique_ptr<Packet> p;
-
-    // While we don't have enough local models
-    while (number_local_models < this->number_client_training)
-    {
-        XBT_INFO("nb local models: %lu", number_local_models);
-        p = nm->get_packet();
-
-        // Note that here we don't check that the local models come from different trainers
-        if (get_if<Packet::SendLocalModel>(&p->op))
-        {
-            number_local_models += 1;
-        }
-    }
-    
-    XBT_INFO("Retrieved %lu local models out of %i", number_local_models, this->number_client_training);
-
-    return number_local_models;
+    this->put_to_be_sent_packet(p);
 }
 
 void SimpleAggregator::send_kills()
 {
+    // Send kills with broadcast
     auto p = make_shared<Packet>(Packet(
-        this->get_network_manager()->get_my_node_name(), "BROADCAST",
+        Filters::trainers_and_aggregators,
         Packet::KillTrainer()
     ));
 
-    this->get_network_manager()->broadcast(p, Filters::trainers_and_aggregators);
+    this->put_to_be_sent_packet(p);
 }

--- a/src/node/roles/aggregator/simple_aggregator.hpp
+++ b/src/node/roles/aggregator/simple_aggregator.hpp
@@ -12,13 +12,14 @@ private:
     // Its the highest class responsability to delete them.
     std::unordered_map<std::string, std::string> *args;
 protected:
+    simgrid::s4u::ExecPtr training_activity;
     void send_global_model();
     uint64_t wait_local_models();
     void send_kills();
 public:
     SimpleAggregator(std::unordered_map<std::string, std::string> *args);
     ~SimpleAggregator();
-    void run();
+    bool run();
 };
 
 #endif // !FALAFELS_SIMPLE_AGGREGATOR_HPP

--- a/src/node/roles/aggregator/simple_aggregator.hpp
+++ b/src/node/roles/aggregator/simple_aggregator.hpp
@@ -6,15 +6,9 @@
 
 class SimpleAggregator : public Aggregator
 {
-private:
-    // Arguments passed to the constructor.
-    // They are kept here because subclass could have to use them.
-    // Its the highest class responsability to delete them.
-    std::unordered_map<std::string, std::string> *args;
-protected:
 public:
     SimpleAggregator(std::unordered_map<std::string, std::string> *args);
-    ~SimpleAggregator();
+    ~SimpleAggregator() {}
     void run();
 };
 

--- a/src/node/roles/aggregator/simple_aggregator.hpp
+++ b/src/node/roles/aggregator/simple_aggregator.hpp
@@ -12,10 +12,6 @@ private:
     // Its the highest class responsability to delete them.
     std::unordered_map<std::string, std::string> *args;
 protected:
-    simgrid::s4u::ExecPtr training_activity;
-    void send_global_model();
-    uint64_t wait_local_models();
-    void send_kills();
 public:
     SimpleAggregator(std::unordered_map<std::string, std::string> *args);
     ~SimpleAggregator();

--- a/src/node/roles/aggregator/simple_aggregator.hpp
+++ b/src/node/roles/aggregator/simple_aggregator.hpp
@@ -19,7 +19,7 @@ protected:
 public:
     SimpleAggregator(std::unordered_map<std::string, std::string> *args);
     ~SimpleAggregator();
-    bool run();
+    void run();
 };
 
 #endif // !FALAFELS_SIMPLE_AGGREGATOR_HPP

--- a/src/node/roles/proxy/proxy.hpp
+++ b/src/node/roles/proxy/proxy.hpp
@@ -10,7 +10,7 @@ private:
     void redirect();
 public:
     Proxy();
-    void run();
+    bool run();
     NodeRole get_role_type() { return NodeRole::Proxy; };
 };
 

--- a/src/node/roles/role.cpp
+++ b/src/node/roles/role.cpp
@@ -1,0 +1,29 @@
+#include "role.hpp"
+#include <optional>
+
+using namespace std;
+
+XBT_LOG_NEW_DEFAULT_CATEGORY(s4u_role, "Messages specific for this example");
+
+optional<unique_ptr<Packet>> Role::get_received_packet()
+{
+    if (this->received_packets->empty())
+        return nullopt;
+
+    auto p = std::move(this->received_packets->front());
+    this->received_packets->pop();
+    return p;
+}
+
+void Role::put_to_be_sent_packet(shared_ptr<Packet> packet)
+{
+    this->to_be_sent_packets->push(std::move(packet));
+}
+
+void Role::set_queues(
+    shared_ptr<queue<unique_ptr<Packet>>> received, 
+    shared_ptr<queue<shared_ptr<Packet>>> to_be_sent)
+{
+    this->received_packets = received;
+    this->to_be_sent_packets = to_be_sent;
+}

--- a/src/node/roles/role.cpp
+++ b/src/node/roles/role.cpp
@@ -15,15 +15,27 @@ optional<unique_ptr<Packet>> Role::get_received_packet()
     return p;
 }
 
-void Role::put_to_be_sent_packet(shared_ptr<Packet> packet)
+void Role::put_to_be_sent_packet(Packet packet)
 {
-    this->to_be_sent_packets->push(std::move(packet));
+    this->to_be_sent_packets->push(make_shared<Packet>(packet));
+}
+
+optional<unique_ptr<NetworkManager::Event>> Role::get_nm_event()
+{
+    if (this->nm_events->empty())
+        return nullopt;
+
+    auto p = std::move(this->nm_events->front());
+    this->nm_events->pop();
+    return p;
 }
 
 void Role::set_queues(
     shared_ptr<queue<unique_ptr<Packet>>> received, 
-    shared_ptr<queue<shared_ptr<Packet>>> to_be_sent)
+    shared_ptr<queue<shared_ptr<Packet>>> to_be_sent,
+    shared_ptr<queue<unique_ptr<NetworkManager::Event>>> nm_events)
 {
     this->received_packets = received;
     this->to_be_sent_packets = to_be_sent;
+    this->nm_events = nm_events;
 }

--- a/src/node/roles/role.hpp
+++ b/src/node/roles/role.hpp
@@ -4,6 +4,8 @@
 
 #include "../network_managers/nm.hpp"
 #include <memory>
+#include <optional>
+#include <queue>
 
 /**
  * Abstract class that defines a Node behaviour in a Federated Learning system.
@@ -15,24 +17,18 @@
 class Role
 {
 private:
-    std::unique_ptr<NetworkManager> network_manager;
+    std::shared_ptr<std::queue<std::unique_ptr<Packet>>> received_packets;
+    std::shared_ptr<std::queue<std::shared_ptr<Packet>>> to_be_sent_packets;
 public:
     Role(){}
     virtual ~Role(){}
-    virtual void run() = 0;
+    virtual bool run() = 0;
     virtual NodeRole get_role_type() = 0;
-    
-    /**
-     * Sets the NetworkManager of the current Role.
-     * @param nm NetworkManager
-     */
-    void set_network_manager(std::unique_ptr<NetworkManager> nm) { this->network_manager = std::move(nm); }
 
-    /**
-     * Get the NetworkManager of the current Role as a raw pointer (non-owning).
-     * @return nm NetworkManager
-     */
-    NetworkManager *get_network_manager() { return this->network_manager.get(); }
+    std::optional<std::unique_ptr<Packet>> get_received_packet();
+    void put_to_be_sent_packet(std::shared_ptr<Packet> packet);
+    void set_queues(std::shared_ptr<std::queue<std::unique_ptr<Packet>>> received, 
+                    std::shared_ptr<std::queue<std::shared_ptr<Packet>>> to_be_sent);
 };
 
 #endif // !FALAFELS_ROLE_HPP

--- a/src/node/roles/role.hpp
+++ b/src/node/roles/role.hpp
@@ -19,16 +19,20 @@ class Role
 private:
     std::shared_ptr<std::queue<std::unique_ptr<Packet>>> received_packets;
     std::shared_ptr<std::queue<std::shared_ptr<Packet>>> to_be_sent_packets;
+    std::shared_ptr<std::queue<std::unique_ptr<NetworkManager::Event>>> nm_events;
 public:
+    bool still_has_activities = true;
     Role(){}
     virtual ~Role(){}
-    virtual bool run() = 0;
+    virtual void run() = 0;
     virtual NodeRole get_role_type() = 0;
 
     std::optional<std::unique_ptr<Packet>> get_received_packet();
-    void put_to_be_sent_packet(std::shared_ptr<Packet> packet);
+    void put_to_be_sent_packet(Packet packet);
+    std::optional<std::unique_ptr<NetworkManager::Event>> get_nm_event();
     void set_queues(std::shared_ptr<std::queue<std::unique_ptr<Packet>>> received, 
-                    std::shared_ptr<std::queue<std::shared_ptr<Packet>>> to_be_sent);
+                    std::shared_ptr<std::queue<std::shared_ptr<Packet>>> to_be_sent,
+                    std::shared_ptr<std::queue<std::unique_ptr<NetworkManager::Event>>> nm_events);
 };
 
 #endif // !FALAFELS_ROLE_HPP

--- a/src/node/roles/trainer/trainer.cpp
+++ b/src/node/roles/trainer/trainer.cpp
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <memory>
+#include <simgrid/s4u/Actor.hpp>
 #include <unordered_map>
 #include <variant>
 #include <xbt/log.h>
@@ -17,55 +18,76 @@ Trainer::Trainer(std::unordered_map<std::string, std::string> *args)
     delete args;
 }
 
-void Trainer::train(uint8_t number_local_epochs) 
+/** 
+ * Launch the training activity or test if the current one has finished.
+ * Performs number_local_epochs training before return true.
+ */
+bool Trainer::train() 
 {
-    double flops = Constants::LOCAL_MODEL_TRAINING_FLOPS;
-
-    XBT_INFO("Starting local training with flops value `%f` and %i epochs", flops, number_local_epochs);
-    for (int i = 0; i < number_local_epochs; i++)
+    // if current training activity is finished
+    if (this->training_activity->test())
     {
-        // XBT_INFO("Epoch %i ====> ...", i);
-        simgrid::s4u::this_actor::execute(flops);
+        // if we need to perform more local epoch
+        if (this->current_local_epoch < this->number_local_epochs)
+        {
+            this->current_local_epoch += 1;
+            double flops = Constants::LOCAL_MODEL_TRAINING_FLOPS;
+
+            // XBT_INFO("Starting local training with flops value `%f` and %i epochs", flops, number_local_epochs);
+
+            XBT_INFO("Epoch %i ====> ...", this->current_local_epoch);
+            this->training_activity = simgrid::s4u::this_actor::exec_async(flops);
+        }
+        else
+        {
+            this->current_local_epoch = 0;
+            // Return true when the last activity have been finished
+            return true;
+        }
     }
+
+    return false;
 }
 
 void Trainer::send_local_model(node_name dst, node_name final_dst)
 {
-    auto nm = this->get_network_manager();
-
     auto p = make_shared<Packet>(Packet(
-        this->get_network_manager()->get_my_node_name(), final_dst,
+        dst, final_dst,
         Packet::SendLocalModel()
     ));
 
-    nm->send(p, dst, 10);
+    this->put_to_be_sent_packet(p);
 }
 
-void Trainer::run()
+bool Trainer::run()
 {
-    auto nm = this->get_network_manager();
-    std::unique_ptr<Packet> p;
-    bool run = true;
-
-    // Wait for the current node to be registered by the Aggregator
-    this->get_network_manager()->send_registration_request();
-
-    while (run)
+    switch (this->state)
     {
-        p = nm->get_packet();
-
-        if (auto *op_glob = get_if<Packet::SendGlobalModel>(&p->op))
-        {
-            this->train(op_glob->number_local_epochs);
-
-            this->send_local_model(p->src, p->original_src);
-        }
-        else if (auto *op_kill = get_if<Packet::KillTrainer>(&p->op))
-        {
-            run = false;
-        }
+        case WAITING_GLOBAL_MODEL:
+            if (auto packet = this->get_received_packet())
+            {
+                if (auto *op_glob = get_if<Packet::SendGlobalModel>(&(*packet)->op))
+                {
+                    this->dst = (*packet)->dst;
+                    this->final_dst = (*packet)->final_dst;
+                    this->number_local_epochs = op_glob->number_local_epochs;
+                    this->state = TRAINING;
+                }
+                else if (get_if<Packet::KillTrainer>(&(*packet)->op))
+                {
+                    // Stop trainer execution
+                    return false;
+                }
+            }
+            break;
+        case TRAINING:
+            if (this->train())
+            {
+                this->send_local_model(this->dst, this->final_dst);
+                this->state = WAITING_GLOBAL_MODEL;
+            }
+            break;
     }
 
-    // Wait last comms before exiting
-    nm->wait_last_comms(2);
+    return true;
 }

--- a/src/node/roles/trainer/trainer.hpp
+++ b/src/node/roles/trainer/trainer.hpp
@@ -12,11 +12,12 @@ class Trainer : public Role
 protected:
     using State = enum
     {
+        INITIALIZING,
         WAITING_GLOBAL_MODEL,
         TRAINING,
     };
 
-    State state;
+    State state = INITIALIZING;
 
     // TODO: find a better way to pass arguments between states
     node_name dst;
@@ -32,7 +33,7 @@ private:
 public:
     Trainer(std::unordered_map<std::string, std::string> *args);
     ~Trainer() {};
-    bool run();
+    void run();
     NodeRole get_role_type() { return NodeRole::Trainer; };
 };
 

--- a/src/node/roles/trainer/trainer.hpp
+++ b/src/node/roles/trainer/trainer.hpp
@@ -4,17 +4,35 @@
 
 #include "../role.hpp"
 #include <cstdint>
+#include <simgrid/forward.h>
 #include <unordered_map>
 
 class Trainer : public Role 
 {
+protected:
+    using State = enum
+    {
+        WAITING_GLOBAL_MODEL,
+        TRAINING,
+    };
+
+    State state;
+
+    // TODO: find a better way to pass arguments between states
+    node_name dst;
+    node_name final_dst;
+
+    uint8_t current_local_epoch = 0;
+    uint8_t number_local_epochs = 0;
+    simgrid::s4u::ExecPtr training_activity;
+
 private:
-    void train(uint8_t number_local_epochs);
+    bool train();
     void send_local_model(node_name dst, node_name final_dst);
 public:
     Trainer(std::unordered_map<std::string, std::string> *args);
     ~Trainer() {};
-    void run();
+    bool run();
     NodeRole get_role_type() { return NodeRole::Trainer; };
 };
 

--- a/src/protocol.hpp
+++ b/src/protocol.hpp
@@ -52,38 +52,34 @@ public:
     struct RegistrationConfirmation 
     { 
         std::shared_ptr<std::vector<NodeInfo>> node_list; // list of nodes attributed by the aggregator.
-        static constexpr std::string_view op_name = "REGISTRATION_CONFIRMATION\0";
-        // static constexpr std::string_view op_name = "\x1B[33mREGISTRATION_CONFIRMATION\033[0m\0";
+        // static constexpr std::string_view op_name = "REGISTRATION_CONFIRMATION\0";
+        static constexpr std::string_view op_name = "\x1B[33mREGISTRATION_CONFIRMATION\033[0m\0";
     };
     struct SendGlobalModel
     {
         uint8_t number_local_epochs; // number of local epochs the trainer should perform.
-        static constexpr std::string_view op_name = "SEND_GLOBAL_MODEL\0";
-        // static constexpr std::string_view op_name = "\x1B[34mSEND_GLOBAL_MODEL\033[0m\0";
+        // static constexpr std::string_view op_name = "SEND_GLOBAL_MODEL\0";
+        static constexpr std::string_view op_name = "\x1B[34mSEND_GLOBAL_MODEL\033[0m\0";
     };
     struct KillTrainer 
     {
-        static constexpr std::string_view op_name = "KILL_TRAINER\0";
-        // static constexpr std::string_view op_name = "\x1B[31mKILL_TRAINER\033[0m\0";
+        // static constexpr std::string_view op_name = "KILL_TRAINER\0";
+        static constexpr std::string_view op_name = "\x1B[31mKILL_TRAINER\033[0m\0";
     };
 
     /* Trainer operations */
     struct RegistrationRequest 
     { 
         NodeInfo node_to_register; // the node that the aggregator should register.
-        static constexpr std::string_view op_name = "REGISTRATION_REQUEST\0";
-        // static constexpr std::string_view op_name = "\x1B[33mREGISTRATION_REQUEST\033[0m\0";
+        // static constexpr std::string_view op_name = "REGISTRATION_REQUEST\0";
+        static constexpr std::string_view op_name = "\x1B[33mREGISTRATION_REQUEST\033[0m\0";
     };
     struct SendLocalModel 
     {
-        static constexpr std::string_view op_name = "SEND_LOCAL_MODEL\0";
-        // static constexpr std::string_view op_name = "\x1B[32mSEND_LOCAL_MODEL\033[0m\0";
+        // static constexpr std::string_view op_name = "SEND_LOCAL_MODEL\0";
+        static constexpr std::string_view op_name = "\x1B[32mSEND_LOCAL_MODEL\033[0m\0";
     };
-    /* -------------------------------------------------------------------------------------------- */
-
-    // Tool to use lambdas in std::visit, see: https://en.cppreference.com/w/cpp/utility/variant/visit
-    template<class... Ts>
-    struct overloaded : Ts... { using Ts::operator()...; };
+    /* -------------------------------------------------------------------------------------------- */ 
 
     // Definition of our Operation variant
     typedef std::variant<
@@ -103,7 +99,7 @@ public:
 
     /** Const src and dst */
     node_name original_src;
-    const node_name final_dst;
+    node_name final_dst;
 
     /** Writable src and dst, usefull in a peer-to-peer scenario */
     node_name src;
@@ -115,9 +111,6 @@ public:
     /** NodeFilter used when broadcast flag is enabled */
     const std::optional<NodeFilter> filter;
 
-    /** Flag indicating if the packet should be send to a bootstrap node */
-    const bool bootstrap;
-
     /** Unique packet identifier */
     packet_id id = 0;
 
@@ -125,17 +118,16 @@ public:
      * both by the cloned packet and the original one. */
     Packet *clone();
 
-    /** Packet constructor with node name used as destinations and final destination */
+    /** Packet constructor both final and intermediate destination, used for peer-to-peer communications with several hops */
     Packet(node_name dst, node_name final_dst, Operation op);
 
     /** Broadcast packet constructor taking NodeFilter instead of concrete destinations */
     Packet(NodeFilter filter, Operation op);
 
-    /** Bootstrap packet constructor, simply sending the packet to a bootstrap node */
-    Packet(Operation op);
-
     ~Packet() {}
 private:
+    /** Intialize fields of a packet */
+    void init();
 
     /** Use to generate new packet ids */
     static inline packet_id total_packet_number = 0;

--- a/src/protocol.hpp
+++ b/src/protocol.hpp
@@ -98,8 +98,8 @@ public:
     const Operation op;
 
     /** Const src and dst */
-    node_name original_src;
-    node_name final_dst;
+    node_name original_src = "";
+    node_name final_dst = "";
 
     /** Writable src and dst, usefull in a peer-to-peer scenario */
     node_name src;

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -13,4 +13,8 @@ constexpr unsigned int str2int(const char* str, int h = 0)
 bool replace_first(std::string& s, std::string const& toReplace, std::string const& replaceWith);
 void replace_all(std::string& s, std::string const& toReplace, std::string const& replaceWith);
 
+// Tool to use lambdas in std::visit (for std::variant), see: https://en.cppreference.com/w/cpp/utility/variant/visit
+template<class... Ts>
+struct overloaded : Ts... { using Ts::operator()...; };
+
 #endif //!FALAFELS_UTILS_HPP


### PR DESCRIPTION
Huge rework of the architecture: Roles and NetworkManagers are now on the same level. Before, roles were controlling the NM which made them unable to operate independently. Now they both execute "in parallel", or more precisely, the node runs infinitely executing one step of NM then one step of role.
Both of those classes implements a state machine making it less bug prone, but more verbose (for the better I hope).

Every connections and tasks (aggregation, training) are now asynchronous, because it is simply easier to handle with this architecture. Though we might implement toggles to be able to intentionally use blocking activities. Note that this will result in NM being unable to execute its tasks in "parallel" if the role is using blocking tasks, and vice-versa.