### PR TITLE
Multiple actor per node

### DIFF
--- a/simulator/CMakeLists.txt
+++ b/simulator/CMakeLists.txt
@@ -16,7 +16,9 @@ include_directories(${SimGrid_INCLUDE_DIR})
 
 set(falafels_files
     src/node/mediator/mediator.hpp
+    src/node/mediator/mediator_consumer.cpp
     src/node/mediator/mediator_consumer.hpp
+    src/node/mediator/mediator_producer.cpp
     src/node/mediator/mediator_producer.hpp
 
     src/node/network_managers/full_nm.cpp

--- a/simulator/src/config_loader.cpp
+++ b/simulator/src/config_loader.cpp
@@ -9,7 +9,7 @@
 
 #include "node/network_managers/nm.hpp"
 #include "node/roles/aggregator/asynchronous_aggregator.hpp"
-// #include "node/roles/aggregator/hierarchical_aggregator.hpp"
+#include "node/roles/aggregator/hierarchical_aggregator.hpp"
 #include "node/roles/aggregator/simple_aggregator.hpp"
 #include "node/roles/trainer/trainer.hpp"
 // #include "node/roles/proxy/proxy.hpp"
@@ -99,7 +99,7 @@ Aggregator *create_aggregator(xml_node *role_elem, unordered_map<string, string>
     else if (strcmp(aggregator_type, "hierarchical") == 0)
     {
         XBT_INFO("With role: Hierarchical");
-        // aggregator = make_unique<HierarchicalAggregator>(args, name);
+        aggregator = new HierarchicalAggregator(args, name);
     }
 
     return aggregator; 

--- a/simulator/src/config_loader.cpp
+++ b/simulator/src/config_loader.cpp
@@ -9,7 +9,7 @@
 
 #include "node/network_managers/nm.hpp"
 #include "node/roles/aggregator/asynchronous_aggregator.hpp"
-#include "node/roles/aggregator/hierarchical_aggregator.hpp"
+// #include "node/roles/aggregator/hierarchical_aggregator.hpp"
 #include "node/roles/aggregator/simple_aggregator.hpp"
 #include "node/roles/trainer/trainer.hpp"
 // #include "node/roles/proxy/proxy.hpp"
@@ -50,24 +50,24 @@ unordered_map<string, string> *parse_arguments(xml_object_range<xml_node_iterato
  * @param topology Topology used in the Node's network.
  * @return A pointer to the created NetworkManager.
  */
-unique_ptr<NetworkManager> create_network_manager(xml_node *network_manager_elem, NodeInfo node_info, string topology)
+NetworkManager *create_network_manager(xml_node *network_manager_elem, NodeInfo node_info, string topology)
 {
-    unique_ptr<NetworkManager> network_manager;
+    NetworkManager *network_manager;
 
     // Topology of the cluster implies the NM type
     auto nm_type = topology.c_str();
 
     if (strcmp(nm_type, "star") == 0)
     {
-        network_manager = make_unique<StarNetworkManager>(node_info);
+        network_manager = new StarNetworkManager(node_info);
     }
     else if (strcmp(nm_type, "ring") == 0)
     {
-        network_manager = make_unique<RingNetworkManager>(node_info);
+        network_manager = new RingNetworkManager(node_info);
     }
     else if (strcmp(nm_type, "full") == 0)
     {
-        network_manager = make_unique<FullyConnectedNetworkManager>(node_info);
+        network_manager = new FullyConnectedNetworkManager(node_info);
     }
 
     XBT_INFO("With %s network manager", nm_type);
@@ -81,25 +81,25 @@ unique_ptr<NetworkManager> create_network_manager(xml_node *network_manager_elem
  * @param args aggregator's arguments already parsed.
  * @return A pointer to the created aggregator.
  */
-unique_ptr<Aggregator> create_aggregator(xml_node *role_elem, unordered_map<string, string> *args, node_name name)
+Aggregator *create_aggregator(xml_node *role_elem, unordered_map<string, string> *args, node_name name)
 {
-    unique_ptr<Aggregator> aggregator;
+    Aggregator *aggregator;
     auto aggregator_type = role_elem->attribute("type").as_string();
 
     if (strcmp(aggregator_type, "simple") == 0)
     {
         XBT_INFO("With role: SimpleAggregator");
-        aggregator = make_unique<SimpleAggregator>(args, name);
+        aggregator = new SimpleAggregator(args, name);
     }
     else if (strcmp(aggregator_type, "asynchronous") == 0)
     {
         XBT_INFO("With role: AsynchronousAggregator");
-        aggregator = make_unique<AsynchronousAggregator>(args, name);
+        aggregator = new AsynchronousAggregator(args, name);
     }
     else if (strcmp(aggregator_type, "hierarchical") == 0)
     {
         XBT_INFO("With role: Hierarchical");
-        aggregator = make_unique<HierarchicalAggregator>(args, name);
+        // aggregator = make_unique<HierarchicalAggregator>(args, name);
     }
 
     return aggregator; 
@@ -110,9 +110,9 @@ unique_ptr<Aggregator> create_aggregator(xml_node *role_elem, unordered_map<stri
  * @param role_elem XML element that contains role informations.
  * @return A pointer to the created Role.
  */
-unique_ptr<Role> create_role(xml_node *role_elem, node_name name)
+Role *create_role(xml_node *role_elem, node_name name)
 {
-    unique_ptr<Role> role;
+    Role *role;
 
     auto args_iter = role_elem->children();
     auto args = parse_arguments(&args_iter);
@@ -123,7 +123,7 @@ unique_ptr<Role> create_role(xml_node *role_elem, node_name name)
     }
     else if (strcmp(role_elem->name(), "trainer") == 0)
     {
-        role = make_unique<Trainer>(args, name);
+        role = new Trainer(args, name);
         XBT_INFO("With role: Trainer");
     }
     else if (strcmp(role_elem->name(), "proxy") == 0)
@@ -149,7 +149,7 @@ Node *create_node(xml_node *node_elem, node_name name, string topology)
     XBT_INFO("Creating node: %s", name.c_str());
 
     xml_node role_elem = node_elem->first_child();
-    unique_ptr<Role> role = create_role(&role_elem, name);
+    Role *role = create_role(&role_elem, name);
 
     NodeInfo node_info = NodeInfo { .name = name, .role=role->get_role_type() };
 
@@ -157,7 +157,7 @@ Node *create_node(xml_node *node_elem, node_name name, string topology)
     auto network_manager = create_network_manager(&network_manager_elem, node_info, topology);
 
     // Returning new falafels node
-    return new Node(std::move(role), std::move(network_manager));
+    return new Node(role, network_manager);
 }
 
 /**

--- a/simulator/src/main.cpp
+++ b/simulator/src/main.cpp
@@ -13,16 +13,6 @@
 
 XBT_LOG_NEW_DEFAULT_CATEGORY(s4u_main, "Messages specific for this example");
 
-void node_runner(Node *node)
-{
-    XBT_INFO("Init node: %s", node->get_node_info().name.c_str());
-    node->run();
-    delete node;
-
-    XBT_INFO("Exiting");
-    simgrid::s4u::this_actor::exit();
-}
-
 int main(int argc, char* argv[])
 {
     simgrid::s4u::Engine e(&argc, argv);
@@ -43,8 +33,9 @@ int main(int argc, char* argv[])
 
     for (auto [name, node] : *nodes_map)
     {
-        XBT_INFO("Creating actor '%s'", name.c_str());
-        auto actor = simgrid::s4u::Actor::create(name, e.host_by_name(name), &node_runner, node); 
+        XBT_INFO("Initializing node '%s'", name.c_str());
+        node->run();
+        // delete node;
     }
 
     /* Run the simulation */

--- a/simulator/src/node/mediator/mediator.hpp
+++ b/simulator/src/node/mediator/mediator.hpp
@@ -4,7 +4,8 @@
 #include <format>
 // #include <simgrid/s4u/MessageQueue.hpp>
 // Temporary work around: using mailbox instead of messageQueues because get_async() is bug on this last
-#include <simgrid/s4u/Mailbox.hpp>
+#include <simgrid/forward.h>
+#include <simgrid/s4u/MessageQueue.hpp>
 #include <simgrid/s4u/ActivitySet.hpp>
 #include <variant>
 #include "../../protocol.hpp"
@@ -38,21 +39,21 @@ protected:
      */
     Mediator(node_name name)
     {
-        this->mq_received_packets = simgrid::s4u::Mailbox::by_name(std::format("{}_mq_rp", name));
-        this->mq_to_be_sent_packets = simgrid::s4u::Mailbox::by_name(std::format("{}_mq_tbsp", name));
-        this->mq_nm_events = simgrid::s4u::Mailbox::by_name(std::format("{}_mq_nme", name));
+        this->mq_received_packets = simgrid::s4u::MessageQueue::by_name(std::format("{}_mq_rp", name));
+        this->mq_to_be_sent_packets = simgrid::s4u::MessageQueue::by_name(std::format("{}_mq_tbsp", name));
+        this->mq_nm_events = simgrid::s4u::MessageQueue::by_name(std::format("{}_mq_nme", name));
 
         this->async_messages = new simgrid::s4u::ActivitySet();
     } 
     
     /** MessageQueue of packets received through the network */
-    simgrid::s4u::Mailbox *mq_received_packets;
+    simgrid::s4u::MessageQueue *mq_received_packets;
 
     /** MessageQueue of packets to send via the network */
-    simgrid::s4u::Mailbox *mq_to_be_sent_packets;
+    simgrid::s4u::MessageQueue *mq_to_be_sent_packets;
 
     /** MessageQueue of events produced by a NetworkManager */
-    simgrid::s4u::Mailbox *mq_nm_events;
+    simgrid::s4u::MessageQueue *mq_nm_events;
 
     simgrid::s4u::ActivitySet *async_messages;
 };

--- a/simulator/src/node/mediator/mediator.hpp
+++ b/simulator/src/node/mediator/mediator.hpp
@@ -2,8 +2,6 @@
 #define FALAFELS_MEDIATOR_HPP
 
 #include <format>
-// #include <simgrid/s4u/MessageQueue.hpp>
-// Temporary work around: using mailbox instead of messageQueues because get_async() is bug on this last
 #include <simgrid/forward.h>
 #include <simgrid/s4u/MessageQueue.hpp>
 #include <simgrid/s4u/ActivitySet.hpp>

--- a/simulator/src/node/mediator/mediator_consumer.cpp
+++ b/simulator/src/node/mediator/mediator_consumer.cpp
@@ -1,0 +1,24 @@
+#include "mediator_consumer.hpp"
+#include <xbt/log.h>
+
+using namespace std;
+
+XBT_LOG_NEW_DEFAULT_CATEGORY(s4u_mediator_consumer, "Messages specific for this example");
+
+unique_ptr<Packet> MediatorConsumer::get_received_packet()
+{
+    return this->mq_received_packets->get_unique<Packet>();
+}
+
+/** Async put a packet to be sent by the NetWorkManager */
+void MediatorConsumer::put_to_be_sent_packet(Packet *packet)
+{
+    auto mess = this->mq_to_be_sent_packets->put_async(packet, 0);
+    this->async_messages->push(mess);
+}
+
+/** Blocking get for retrieving a NetworkManager Event */
+unique_ptr<Mediator::Event> MediatorConsumer::get_nm_event()
+{
+    return this->mq_nm_events->get_unique<Event>();
+}

--- a/simulator/src/node/mediator/mediator_consumer.cpp
+++ b/simulator/src/node/mediator/mediator_consumer.cpp
@@ -13,7 +13,7 @@ unique_ptr<Packet> MediatorConsumer::get_received_packet()
 /** Async put a packet to be sent by the NetWorkManager */
 void MediatorConsumer::put_to_be_sent_packet(Packet *packet)
 {
-    auto mess = this->mq_to_be_sent_packets->put_async(packet, 0);
+    auto mess = this->mq_to_be_sent_packets->put_async(packet);
     this->async_messages->push(mess);
 }
 

--- a/simulator/src/node/mediator/mediator_consumer.hpp
+++ b/simulator/src/node/mediator/mediator_consumer.hpp
@@ -15,38 +15,16 @@ using namespace std;
 class MediatorConsumer : public Mediator
 {
 public:
-    MediatorConsumer(std::shared_ptr<std::queue<std::unique_ptr<Packet>>> received, 
-                    std::shared_ptr<std::queue<std::shared_ptr<Packet>>> to_be_sent,
-                    std::shared_ptr<std::queue<std::unique_ptr<Event>>> nm_events)
-    : Mediator(received, to_be_sent, nm_events) {}
+    MediatorConsumer(node_name name) : Mediator(name) {}
 
-    /** Optionally get a Packet if available */
-    std::optional<std::unique_ptr<Packet>> get_received_packet()
-    {
-        if (this->received_packets->empty())
-            return nullopt;
+    /** Blocking get for retrieving a received packet */
+    std::unique_ptr<Packet> get_received_packet();
 
-        auto p = std::move(this->received_packets->front());
-        this->received_packets->pop();
-        return p;
-    }
+    /** Async put a packet to be sent by the NetWorkManager */
+    void put_to_be_sent_packet(Packet *packet);
 
-    /** Put a packet to be sent by the NetWorkManager */
-    void put_to_be_sent_packet(Packet packet)
-    {
-        this->to_be_sent_packets->push(make_shared<Packet>(packet));
-    }
-
-    /** Optionally get a NetworkManager Event if available */
-    std::optional<std::unique_ptr<Event>> get_nm_event()
-    {
-        if (this->nm_events->empty())
-            return nullopt;
-
-        auto p = std::move(this->nm_events->front());
-        this->nm_events->pop();
-        return p;
-    }
+    /** Blocking get for retrieving a NetworkManager Event */
+    std::unique_ptr<Event> get_nm_event();
 };
 
 #endif // !FALAFELS_MEDIATOR_CONSUMER_HPP

--- a/simulator/src/node/mediator/mediator_producer.cpp
+++ b/simulator/src/node/mediator/mediator_producer.cpp
@@ -14,7 +14,7 @@ shared_ptr<Packet> MediatorProducer::get_to_be_sent_packet()
 }
 
 /** Async get for retrieving a packet to be sent */
-simgrid::s4u::CommPtr MediatorProducer::get_async_to_be_sent_packet()
+simgrid::s4u::MessPtr MediatorProducer::get_async_to_be_sent_packet()
 {
     return this->mq_to_be_sent_packets->get_async();
 }
@@ -23,13 +23,13 @@ simgrid::s4u::CommPtr MediatorProducer::get_async_to_be_sent_packet()
 /** Async put a packet received by the network */
 void MediatorProducer::put_received_packet(Packet *packet)
 {
-    auto mess = this->mq_received_packets->put_async(packet, 0);
+    auto mess = this->mq_received_packets->put_async(packet);
     this->async_messages->push(mess);
 }
 
 /** Async put a new NetworkManager Event */
 void MediatorProducer::put_nm_event(Event *e)
 {
-    auto mess = this->mq_nm_events->put_async(e, 0);
+    auto mess = this->mq_nm_events->put_async(e);
     this->async_messages->push(mess);
 }

--- a/simulator/src/node/mediator/mediator_producer.cpp
+++ b/simulator/src/node/mediator/mediator_producer.cpp
@@ -1,0 +1,35 @@
+#include "mediator_producer.hpp"
+
+using namespace std;
+
+XBT_LOG_NEW_DEFAULT_CATEGORY(s4u_mediator_producer, "Messages specific for this example");
+
+shared_ptr<Packet> MediatorProducer::get_to_be_sent_packet()
+{
+    auto tmp = this->mq_to_be_sent_packets->get<Packet>();
+    auto res = std::make_shared<Packet>(*tmp);
+    delete tmp;
+
+    return res;
+}
+
+/** Async get for retrieving a packet to be sent */
+simgrid::s4u::CommPtr MediatorProducer::get_async_to_be_sent_packet()
+{
+    return this->mq_to_be_sent_packets->get_async();
+}
+
+
+/** Async put a packet received by the network */
+void MediatorProducer::put_received_packet(Packet *packet)
+{
+    auto mess = this->mq_received_packets->put_async(packet, 0);
+    this->async_messages->push(mess);
+}
+
+/** Async put a new NetworkManager Event */
+void MediatorProducer::put_nm_event(Event *e)
+{
+    auto mess = this->mq_nm_events->put_async(e, 0);
+    this->async_messages->push(mess);
+}

--- a/simulator/src/node/mediator/mediator_producer.hpp
+++ b/simulator/src/node/mediator/mediator_producer.hpp
@@ -3,6 +3,8 @@
 
 
 #include "mediator.hpp"
+#include <simgrid/forward.h>
+// #include <simgrid/s4u/Mess.hpp>
 
 using namespace std;
 
@@ -16,33 +18,19 @@ using namespace std;
 class MediatorProducer : public Mediator
 {
 public:
-    MediatorProducer(std::shared_ptr<std::queue<std::unique_ptr<Packet>>> received, 
-                    std::shared_ptr<std::queue<std::shared_ptr<Packet>>> to_be_sent,
-                    std::shared_ptr<std::queue<std::unique_ptr<Event>>> nm_events)
-    : Mediator(received, to_be_sent, nm_events) {}
+    MediatorProducer(node_name name) : Mediator(name) {}
 
-    /** Optionally get packet to be sent if some */
-    std::optional<std::shared_ptr<Packet>> get_to_be_sent_packet()
-    {
-        if (this->to_be_sent_packets->empty())
-            return nullopt;
+    /** Blocking get for retrieving a packet to be sent */
+    std::shared_ptr<Packet> get_to_be_sent_packet();
 
-        auto p = std::move(this->to_be_sent_packets->front());
-        this->to_be_sent_packets->pop();
-        return p;
-    }
+    /** Async get for retrieving a packet to be sent */
+    simgrid::s4u::CommPtr get_async_to_be_sent_packet();
 
-    /** Put a packet received by the network to the received packets */
-    void put_received_packet(std::unique_ptr<Packet> packet)
-    {
-        this->received_packets->push(std::move(packet));
-    }
+    /** Async put a packet received by the network */
+    void put_received_packet(Packet *packet);
 
-    /** Put a new event */
-    void put_nm_event(Event e)
-    {
-        this->nm_events->push(make_unique<Event>(e));
-    }
+    /** Async put a new NetworkManager Event */
+    void put_nm_event(Event *e);
 };
 
 #endif // !FALAFELS_MEDIATOR_PRODUCER_HPP

--- a/simulator/src/node/mediator/mediator_producer.hpp
+++ b/simulator/src/node/mediator/mediator_producer.hpp
@@ -3,8 +3,7 @@
 
 
 #include "mediator.hpp"
-#include <simgrid/forward.h>
-// #include <simgrid/s4u/Mess.hpp>
+#include <simgrid/s4u/Mess.hpp>
 
 using namespace std;
 
@@ -24,7 +23,7 @@ public:
     std::shared_ptr<Packet> get_to_be_sent_packet();
 
     /** Async get for retrieving a packet to be sent */
-    simgrid::s4u::CommPtr get_async_to_be_sent_packet();
+    simgrid::s4u::MessPtr get_async_to_be_sent_packet();
 
     /** Async put a packet received by the network */
     void put_received_packet(Packet *packet);

--- a/simulator/src/node/network_managers/full_nm.cpp
+++ b/simulator/src/node/network_managers/full_nm.cpp
@@ -68,19 +68,21 @@ void FullyConnectedNetworkManager::handle_registration_requests()
             std::format("{} -> {} [color=green]", this->my_node_info.name, request.node_to_register.name)
         );
 
-        auto res_p = make_shared<Packet>(Packet(
+        auto res_p = new Packet(
             request.node_to_register.name, request.node_to_register.name,
             Packet::RegistrationConfirmation {
                 // Here full list is sent, including the same node that we send the packet to
                 .node_list=nodes_to_connect
             }
-        ));
+        );
 
         this->send_async(res_p);
     }
 
     this->mp->put_nm_event(
-        Mediator::ClusterConnected { .number_client_connected=(uint16_t)this->connected_nodes->size() }
+        new Mediator::Event {
+            Mediator::ClusterConnected { .number_client_connected=(uint16_t)this->connected_nodes->size() }
+        }
     );
 }
 
@@ -92,12 +94,12 @@ void FullyConnectedNetworkManager::send_registration_request()
     // Take the first bootstrap node, in a centralized topology we should have only one anyways.
     auto bootstrap_node = this->bootstrap_nodes->at(0);
 
-    auto p = make_shared<Packet>(Packet(
+    auto p = new Packet(
         bootstrap_node.name, bootstrap_node.name,
         Packet::RegistrationRequest(
             this->my_node_info
         )
-    ));
+    );
 
     this->send_async(p);
 }
@@ -112,24 +114,26 @@ void FullyConnectedNetworkManager::handle_registration_confirmation(const Packet
             this->connected_nodes->push_back(node);
     }
 
-    this->mp->put_nm_event(Mediator::NodeConnected {});
+    this->mp->put_nm_event(
+        new Mediator::Event {Mediator::NodeConnected {} }
+    );
 }
 
-void FullyConnectedNetworkManager::broadcast(shared_ptr<Packet> packet)
+void FullyConnectedNetworkManager::broadcast(Packet *p)
 {
     for(auto node_info : *this->connected_nodes)
     {
         // Apply the filter function and send if it returned true
-        if ((*packet->filter)(&node_info))
+        if ((*p->filter)(&node_info))
         {
-            packet->dst = node_info.name;
-            this->send_async(packet);
+            p->dst = node_info.name;
+            this->send_async(p);
         }
     }
 }
 
-void FullyConnectedNetworkManager::route_packet(unique_ptr<Packet> packet)
+void FullyConnectedNetworkManager::route_packet(Packet *p)
 {
     // In full_nm we route everything to the Role.
-    this->mp->put_received_packet(std::move(packet));
+    this->mp->put_received_packet(p);
 }

--- a/simulator/src/node/network_managers/full_nm.hpp
+++ b/simulator/src/node/network_managers/full_nm.hpp
@@ -19,8 +19,8 @@ public:
     void handle_registration_requests();
     void send_registration_request();
     void handle_registration_confirmation(const Packet::RegistrationConfirmation &confirmation);
-    void route_packet(std::unique_ptr<Packet> packet);
-    void broadcast(std::shared_ptr<Packet>);
+    void route_packet(Packet *p);
+    void broadcast(Packet *p);
 };
 
 #endif // !FALAFELS_FULLYCONNECTED_NM_HPP

--- a/simulator/src/node/network_managers/nm.cpp
+++ b/simulator/src/node/network_managers/nm.cpp
@@ -152,6 +152,7 @@ void NetworkManager::run()
                         // Clear all async put before sending and waiting the kill packet
                         this->pending_async_put->clear();
 
+                        //---------------------------------------------
                         // TODO: make this better if possible......
                         // In case we are the hierarchical_nm
                         if (this->my_node_info.name.contains("hierarchical"))
@@ -163,6 +164,13 @@ void NetworkManager::run()
                             p->final_dst = cluster_nm_name;
                             this->send_async(p, true);
                         }
+
+                        // Case where we receive kill packet from hierarchical_nm
+                        if (this->my_node_info.role == NodeRole::Aggregator)
+                        {
+                            this->send_packet(p);
+                        }
+                        //---------------------------------------------
                     }
 
 
@@ -268,7 +276,7 @@ void NetworkManager::send_packet(Packet *p)
     }
 
     // Send and broadcast should clone the pointer internally, so we can delete the packet here.
-    delete p;
+    // delete p;
 }
 
 void NetworkManager::send_async(Packet *p, bool is_redirected)

--- a/simulator/src/node/network_managers/ring_nm.cpp
+++ b/simulator/src/node/network_managers/ring_nm.cpp
@@ -66,17 +66,17 @@ void RingNetworkManager::handle_registration_requests()
         neigbours.push_back(left_n);
         neigbours.push_back(right_n);
 
-        auto res_p = make_shared<Packet>(Packet(
+        auto res_p = new Packet(
             this->registration_requests->at(i).node_to_register.name, // Sent the packet to the current node
             this->registration_requests->at(i).node_to_register.name, // Sent the packet to the current node
             Packet::RegistrationConfirmation(
                 make_shared<vector<NodeInfo>>(neigbours)
             )
-        ));
+        );
 
         // Sending the packet
         this->send_async(res_p);
-    } 
+    }
 
     DOTGenerator::get_instance().add_to_cluster(
         std::format("cluster-{}", this->my_node_info.name),
@@ -89,7 +89,9 @@ void RingNetworkManager::handle_registration_requests()
     );
 
     this->mp->put_nm_event(
-        Mediator::ClusterConnected { .number_client_connected=(uint16_t)this->registration_requests->size() }
+        new Mediator::Event {
+            Mediator::ClusterConnected { .number_client_connected=(uint16_t)this->registration_requests->size() }
+        }
     );
 }
 
@@ -100,12 +102,12 @@ void RingNetworkManager::send_registration_request()
     // Take the first bootstrap node. TODO: handle multiple bootstrap nodes??
     auto bootstrap_node = this->bootstrap_nodes->at(0);
 
-    auto p = make_shared<Packet>(Packet(
+    auto p = new Packet(
         bootstrap_node.name, bootstrap_node.name, 
         Packet::RegistrationRequest(
             this->my_node_info
         )
-    ));
+    );
 
     // Send the request
     this->send_async(p);
@@ -135,53 +137,55 @@ void RingNetworkManager::handle_registration_confirmation(const Packet::Registra
         std::format("{} -> {} [color=green]", this->my_node_info.name, this->right_node.name)
     );
 
-    this->mp->put_nm_event(Mediator::NodeConnected {});
+    this->mp->put_nm_event(
+        new Mediator::Event { Mediator::NodeConnected {} }
+    );
 }
 
-void RingNetworkManager::route_packet(std::unique_ptr<Packet> packet)
+void RingNetworkManager::route_packet(Packet *p)
 {
     // Check that the packet haven't been already received
-    if(!this->is_duplicated(packet->id))
+    if(!this->is_duplicated(p->id))
     {
         // Add to received packets
-        this->received_packet_ids->push_back(packet->id);
+        this->received_packet_ids->push_back(p->id);
 
         // if the packet has broadcast enabled or if dst is not for the current node
-        if (packet->broadcast || packet->final_dst != this->get_my_node_name())
+        if (p->broadcast || p->final_dst != this->get_my_node_name())
         {
-            this->redirect(packet);
+            this->redirect(p);
         }
 
         // if its a broadcast, then the msg has to be delivered to everyone (including us)
         // or if the final dst is equal to our name, then we are the final_dst.
-        if (packet->broadcast || packet->final_dst == this->get_my_node_name())
+        if (p->broadcast || p->final_dst == this->get_my_node_name())
         {
-            this->mp->put_received_packet(std::move(packet));
+            this->mp->put_received_packet(p);
         }
     }
     else 
     {
-        XBT_INFO("Discarding packet %lu: duplicate", packet->id);
+        XBT_INFO("Discarding packet %lu: duplicate", p->id);
     }
 }
 
-void RingNetworkManager::broadcast(shared_ptr<Packet> packet) 
+void RingNetworkManager::broadcast(Packet *p) 
 {
     uint16_t res = 0;
 
     // Apply filter function and send to left node
-    if ((*packet->filter)(&this->left_node))
+    if ((*p->filter)(&this->left_node))
     {
-        packet->dst = this->left_node.name;
-        this->send_async(packet);
+        p->dst = this->left_node.name;
+        this->send_async(p);
         res++;
     }
 
     // Apply filter function and send to right node
-    if ((*packet->filter)(&this->right_node))
+    if ((*p->filter)(&this->right_node))
     {
-        packet->dst = this->right_node.name;
-        this->send_async(packet);
+        p->dst = this->right_node.name;
+        this->send_async(p);
         res++;
     }
 }
@@ -194,12 +198,10 @@ bool RingNetworkManager::is_duplicated(const packet_id id)
     return find(r->begin(), r->end(), id) != r->end();
 }
 
-void RingNetworkManager::redirect(unique_ptr<Packet> &p)
+void RingNetworkManager::redirect(Packet *p)
 {
-    auto new_p = make_shared<Packet>(*p);
-
     node_name dst;
-    // If the original packet came from our left
+    // If the packet came from our left
     if (p->src == this->left_node.name) 
     {
         // Send to the right
@@ -211,9 +213,9 @@ void RingNetworkManager::redirect(unique_ptr<Packet> &p)
         dst = this->left_node.name;
     }
 
-    new_p->dst = dst;
+    p->dst = dst;
     
     // Note that the final dst stays the same.
     // We specify is_redirected to true to prevent the orginal src from being overwritten.
-    this->send_async(new_p, true);
+    this->send_async(p, true);
 }

--- a/simulator/src/node/network_managers/ring_nm.hpp
+++ b/simulator/src/node/network_managers/ring_nm.hpp
@@ -24,7 +24,7 @@ private:
     bool is_duplicated(const packet_id);
     
     /** Redirect a packet to a neighbour of the ring */
-    void redirect(std::unique_ptr<Packet>&);
+    void redirect(Packet *p);
 public:
     RingNetworkManager(NodeInfo);
     ~RingNetworkManager();
@@ -33,8 +33,8 @@ public:
     void handle_registration_requests();
     void send_registration_request();
     void handle_registration_confirmation(const Packet::RegistrationConfirmation &confirmation);
-    void route_packet(std::unique_ptr<Packet> packet);
-    void broadcast(std::shared_ptr<Packet>);
+    void route_packet(Packet *p);
+    void broadcast(Packet *p);
 };
 
 #endif // !FALAFELS_DECENTRALIZED_NM_HPP

--- a/simulator/src/node/network_managers/star_nm.hpp
+++ b/simulator/src/node/network_managers/star_nm.hpp
@@ -19,8 +19,8 @@ public:
     void handle_registration_requests();
     void send_registration_request();
     void handle_registration_confirmation(const Packet::RegistrationConfirmation &confirmation);
-    void route_packet(std::unique_ptr<Packet> packet);
-    void broadcast(std::shared_ptr<Packet>);
+    void route_packet(Packet *packet);
+    void broadcast(Packet *packet);
 };
 
 #endif // !FALAFELS_CENTRALIZED_NM_HPP

--- a/simulator/src/node/node.cpp
+++ b/simulator/src/node/node.cpp
@@ -17,6 +17,8 @@ Node::Node(Role *r, NetworkManager *nm)
     this->role = r;
     this->network_manager = nm;
 
+    // TODO: can simplify that and directly put it into the Role and NetworkManager constructors.
+    // Though we might also unify the data and the way ther are passed to them, i.e. the NodeInfo.
     auto mc = make_unique<MediatorConsumer>(this->get_node_info().name);
     auto mp = make_unique<MediatorProducer>(this->get_node_info().name);
 
@@ -31,11 +33,11 @@ void Node::run()
 
     simgrid::s4u::Actor::create(
         std::format("{}_role", name), e->host_by_name(name), &Node::run_role, this->role
-    ); 
+    );
 
     simgrid::s4u::Actor::create(
         std::format("{}_nm", name), e->host_by_name(name), &Node::run_network_manager, this->network_manager
-    ); 
+    );
 }
 
 NodeInfo Node::get_node_info()

--- a/simulator/src/node/node.cpp
+++ b/simulator/src/node/node.cpp
@@ -1,7 +1,9 @@
 #include "node.hpp"
 #include "mediator/mediator_producer.hpp"
 #include "network_managers/nm.hpp"
+#include <format>
 #include <memory>
+#include <simgrid/s4u/Engine.hpp>
 #include <utility>
 #include <vector>
 #include <xbt/log.h>
@@ -10,18 +12,13 @@ using namespace std;
 
 XBT_LOG_NEW_DEFAULT_CATEGORY(s4u_node, "Messages specific for this example");
 
-Node::Node(unique_ptr<Role> r, unique_ptr<NetworkManager> nm)
+Node::Node(Role *r, NetworkManager *nm)
 {
-    this->role = std::move(r);
-    this->network_manager = std::move(nm);
+    this->role = r;
+    this->network_manager = nm;
 
-    // Creates queues to enable communication between Role and NM.
-    auto received_packets = make_shared<queue<unique_ptr<Packet>>>();
-    auto to_be_sent_packets = make_shared<queue<shared_ptr<Packet>>>();
-    auto nm_events = make_shared<queue<unique_ptr<Mediator::Event>>>();
-
-    auto mc = make_unique<MediatorConsumer>(received_packets, to_be_sent_packets, nm_events);
-    auto mp = make_unique<MediatorProducer>(received_packets, to_be_sent_packets, nm_events);
+    auto mc = make_unique<MediatorConsumer>(this->get_node_info().name);
+    auto mp = make_unique<MediatorProducer>(this->get_node_info().name);
 
     this->role->set_mediator_consumer(std::move(mc));
     this->network_manager->set_mediator_producer(std::move(mp));
@@ -29,16 +26,16 @@ Node::Node(unique_ptr<Role> r, unique_ptr<NetworkManager> nm)
 
 void Node::run()
 {
-    while(true)
-    {
-        simgrid::s4u::this_actor::sleep_for(0.01);
+    node_name name = this->get_node_info().name;
+    auto e = simgrid::s4u::Engine::get_instance();
 
-        this->role->run();
+    simgrid::s4u::Actor::create(
+        std::format("{}_role", name), e->host_by_name(name), &Node::run_role, this->role
+    ); 
 
-        // Breaks when NetworkManager run() returns false
-        if (!this->network_manager->run())
-            break;
-    }
+    simgrid::s4u::Actor::create(
+        std::format("{}_nm", name), e->host_by_name(name), &Node::run_network_manager, this->network_manager
+    ); 
 }
 
 NodeInfo Node::get_node_info()

--- a/simulator/src/node/node.hpp
+++ b/simulator/src/node/node.hpp
@@ -25,16 +25,6 @@ class Node
 private:
     Role *role;
     NetworkManager *network_manager; 
-
-    static void run_role(Role *r)
-    {
-        while (true) { r->run(); }; delete r;
-    }
-
-    static void run_network_manager(NetworkManager *nm)
-    {
-        while (true) { nm->run(); }; delete nm;
-    }
 public:
     /**
      * Node constructor
@@ -76,6 +66,16 @@ public:
      * @return NodeInfo*.
      */
     NodeInfo get_node_info();
+
+    static void run_role(Role *r)
+    {
+        while (true) { r->run(); }; delete r;
+    }
+
+    static void run_network_manager(NetworkManager *nm)
+    {
+        while (true) { nm->run(); }; delete nm;
+    }
 };
 
 #endif // !FALAFELS_NODE_HPP

--- a/simulator/src/node/node.hpp
+++ b/simulator/src/node/node.hpp
@@ -23,15 +23,25 @@
 class Node
 {
 private:
-    std::unique_ptr<Role> role;
-    std::unique_ptr<NetworkManager> network_manager; 
+    Role *role;
+    NetworkManager *network_manager; 
+
+    static void run_role(Role *r)
+    {
+        while (true) { r->run(); }; delete r;
+    }
+
+    static void run_network_manager(NetworkManager *nm)
+    {
+        while (true) { nm->run(); }; delete nm;
+    }
 public:
     /**
      * Node constructor
      * @param r Node's Role
      * @param nm Node's NetworkManager
      */
-    Node(std::unique_ptr<Role> r, std::unique_ptr<NetworkManager> nm);
+    Node(Role *r, NetworkManager *nm);
 
     /**
      * Node's NetworkManager and Role are deleted implicitly with the unique pointers.
@@ -59,7 +69,7 @@ public:
      * Get the Node's Role.
      * @return Node's Role.
      */
-    Role *get_role() { return role.get(); }
+    Role *get_role() { return role; }
 
     /**
      * Return a NodeInfo struct representing Node's information.

--- a/simulator/src/node/roles/aggregator/aggregator.cpp
+++ b/simulator/src/node/roles/aggregator/aggregator.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <simgrid/s4u/Engine.hpp>
 #include <xbt/asserts.h>
 #include <xbt/log.h>
@@ -14,68 +15,70 @@ Aggregator::Aggregator(node_name name)
     this->aggregating_activities = new simgrid::s4u::ActivitySet();
 }
 
-void Aggregator::launch_one_aggregation()
+void Aggregator::run_one_aggregation()
 {
-    XBT_INFO("Starting aggregation of model %lu", this->current_number_aggregated_models);
-    this->current_number_aggregated_models += 1;
-
     double flops = Constants::GLOBAL_MODEL_AGGREGATING_FLOPS;
 
     int nb_core = simgrid::s4u::this_actor::get_host()->get_core_count();
-    double nb_flops_per_aggregation = flops / nb_core;
 
-    XBT_DEBUG("flops / nb_core = nb_flops_per_aggregation: %f / %i = %f", flops, nb_core, nb_flops_per_aggregation);
+    // Number for one aggregation splitted in one core
+    double nb_flops_per_core = flops / nb_core;
+
+    XBT_DEBUG("flops / nb_core = nb_flops_per_core: %f / %i = %f", flops, nb_core, nb_flops_per_core);
     
     // Launch exactly nb_core parallel tasks
     for (int i = 0; i < nb_core; i++)
     {
-        this->aggregating_activities->push(simgrid::s4u::this_actor::exec_async(nb_flops_per_aggregation));
+        this->aggregating_activities->push(simgrid::s4u::this_actor::exec_async(nb_flops_per_core));
     }
+
+    this->aggregating_activities->wait_all();
 }
 
-bool Aggregator::aggregate() 
+void Aggregator::run_multiple_aggregation(uint64_t number_local_models)
 {
-    // if aggregating activity doesn't exists
-    if (this->aggregating_activities->empty())
+    double flops = Constants::GLOBAL_MODEL_AGGREGATING_FLOPS;
+
+    int nb_core = simgrid::s4u::this_actor::get_host()->get_core_count();
+
+    // Number for one aggregation splitted in one core
+    double nb_flops_per_core = flops / nb_core;
+
+    // Total number of flops for every aggregations in one core 
+    double total_nb_flops_per_core = nb_flops_per_core * number_local_models;
+
+    XBT_DEBUG("(flops / nb_core) * number_local_models = total_nb_flops_per_core: (%f / %i) * %lu = %f", flops, nb_core, number_local_models, nb_flops_per_core);
+    
+    // Launch exactly nb_core parallel tasks
+    for (int i = 0; i < nb_core; i++)
     {
-        this->launch_one_aggregation();
+        this->aggregating_activities->push(simgrid::s4u::this_actor::exec_async(total_nb_flops_per_core));
     }
 
-    // Test if any activity finished
-    auto activity = this->aggregating_activities->test_any();
+    this->aggregating_activities->wait_all();
+}
 
-    // If the activity isn't nullptr, remove it for the ActivitySet
-    if (activity != nullptr)
+void Aggregator::aggregate() 
+{
+    if (this->number_local_models == 1)
     {
-        // Because the workload is splitted evently between each cores, we know that when one activity finished,
-        // every others have finished too.
-        this->aggregating_activities->clear(); 
-
-        // if we need to perform more model aggregation, start a new aggregation task
-        if (this->current_number_aggregated_models < this->number_local_models)
-        {
-            this->launch_one_aggregation();
-        }
-        else
-        {
-            // Increment the number of aggregated models
-            this->total_aggregated_models += this->number_local_models;
-            // Reset the current number of aggregated models
-            this->current_number_aggregated_models = 0;
-            // Compute the number of global epochs
-            this->number_global_epochs = this->total_aggregated_models / this->number_client_training;
-            // Return true when the last activity have been finished
-            return true;
-        }
+        this->run_one_aggregation();
+    }
+    else 
+    {
+        this->run_multiple_aggregation(this->number_local_models);
     }
 
-    return false; 
+    // Increment the number of aggregated models
+    this->total_aggregated_models += this->number_local_models;
+    // Compute the number of global epochs
+    this->number_global_epochs = this->total_aggregated_models / this->number_client_training;
 }
 
 void Aggregator::send_global_model()
 {
     this->mc->put_to_be_sent_packet(
-        Packet(
+        new Packet(
             // Send global model with broadcast because we specify a filter instead of a dst
             Filters::trainers_and_aggregators,
             Packet::SendGlobalModel(
@@ -88,19 +91,22 @@ void Aggregator::send_global_model()
 void Aggregator::send_kills()
 {
     this->mc->put_to_be_sent_packet(
-        Packet(
+        new Packet(
             // Send kills with broadcast
             Filters::trainers_and_aggregators,
             Packet::KillTrainer()
         )
     );
+
+    this->mc->wait_all_async_comms();
 }
 
 bool Aggregator::check_end_condition()
 { 
     if (Constants::END_CONDITION_DURATION_TRAINING_PHASE != -1.0)
     {
-        return simgrid::s4u::Engine::get_instance()->get_clock() > this->initialization_time + Constants::END_CONDITION_DURATION_TRAINING_PHASE;
+        xbt_assert(false, "NOT IMPLEMENTED");
+        // return simgrid::s4u::Engine::get_instance()->get_clock() > this->initialization_time + Constants::END_CONDITION_DURATION_TRAINING_PHASE;
     }
     else if (Constants::END_CONDITION_NUMBER_GLOBAL_EPOCHS != 0)
     {

--- a/simulator/src/node/roles/aggregator/aggregator.hpp
+++ b/simulator/src/node/roles/aggregator/aggregator.hpp
@@ -10,18 +10,6 @@
 
 class Aggregator : public Role 
 {
-private:
-    /**
-     * Run and wait one aggregation step in parallel, sharing activities among the Host's cores.
-     */
-    void run_one_aggregation();
-
-    /**
-     * Run and wait all aggregations steps in parallel, sharing activities among the Host's cores.
-     * This method groups all tasks into a big one, which is way more efficient (in terms of simulation runtime) 
-     * than executing tasks one by one.
-     */
-    void run_multiple_aggregation(uint64_t number_local_models);
 protected:
     /** Value indicating the number of local epochs that the aggregator will ask the trainers to do. */
     uint8_t number_local_epochs = 3;
@@ -44,8 +32,10 @@ protected:
     /** Time when the aggregator has been initialized */
     double initialization_time;
 
-    /** 
-     * Run and wait the aggregating activities.
+    /**
+     * Run and wait all aggregations steps in parallel, sharing activities among the Host's cores.
+     * Groups all tasks into a big one, which is way more efficient (in terms of simulation runtime) 
+     * than executing tasks one by one.
      */
     void aggregate();
 

--- a/simulator/src/node/roles/aggregator/aggregator.hpp
+++ b/simulator/src/node/roles/aggregator/aggregator.hpp
@@ -10,6 +10,18 @@
 
 class Aggregator : public Role 
 {
+private:
+    /**
+     * Run and wait one aggregation step in parallel, sharing activities among the Host's cores.
+     */
+    void run_one_aggregation();
+
+    /**
+     * Run and wait all aggregations steps in parallel, sharing activities among the Host's cores.
+     * This method groups all tasks into a big one, which is way more efficient (in terms of simulation runtime) 
+     * than executing tasks one by one.
+     */
+    void run_multiple_aggregation(uint64_t number_local_models);
 protected:
     /** Value indicating the number of local epochs that the aggregator will ask the trainers to do. */
     uint8_t number_local_epochs = 3;
@@ -29,25 +41,13 @@ protected:
     /** Simgrid activity representing the training */
     simgrid::s4u::ActivitySet *aggregating_activities;
 
-    /** Number of aggregated models on one aggregation task */
-    uint64_t current_number_aggregated_models = 0;
-
     /** Time when the aggregator has been initialized */
     double initialization_time;
 
-    /** Boolean indicating if the Aggregator still has activities to perform */
-    bool still_has_activities = true;
-
-    /**
-     * Launch one aggregation step in parallel, sharing activities among the Host's cores.
-     */
-    void launch_one_aggregation(); 
-
     /** 
-     * Launch the aggregating activity or test if the current one has finished.
-     * @return true when aggregation is finished, otherwise false.
+     * Run and wait the aggregating activities.
      */
-    bool aggregate();
+    void aggregate();
 
     /** 
      * Sends the global model with a broadcast. It should sent it to every connected nodes of our cluster.

--- a/simulator/src/node/roles/aggregator/asynchronous_aggregator.cpp
+++ b/simulator/src/node/roles/aggregator/asynchronous_aggregator.cpp
@@ -33,62 +33,59 @@ AsynchronousAggregator::AsynchronousAggregator(std::unordered_map<std::string, s
 
 void AsynchronousAggregator::run()
 {
-    if (!this->still_has_activities)
-        return;
-
-    if (this->check_end_condition())
-    {
-        // Stop aggregating and send kills to the trainers
-        this->send_kills();
-        this->print_end_report();
-        this->still_has_activities = false;
-        return;
-    }
-
     switch (this->state)
     {
         case INITIALIZING:
-            // If a NetworkManager event is available
-            if (auto e = this->mc->get_nm_event())
             {
+                auto e = this->mc->get_nm_event();
+
                 // If type of event is ClusterConnected it means that every node have been connected to us
-                if (auto *conneted_event = get_if<Mediator::ClusterConnected>(e->get()))
+                if (auto *conneted_event = get_if<Mediator::ClusterConnected>(e.get()))
                 {
                     this->number_client_training = conneted_event->number_client_connected;
                     this->send_global_model();
                     this->state = WAITING_LOCAL_MODELS;
                 }
+                break;
             }
-            break;
         case WAITING_LOCAL_MODELS:
-            // If a packet have been received
-            if (auto packet = this->mc->get_received_packet())
             {
+                auto packet = this->mc->get_received_packet();
+
                 // If the operation is a SendLocalModel
-                if (auto *send_local = get_if<Packet::SendLocalModel>(&(*packet)->op))
+                if (auto *send_local = get_if<Packet::SendLocalModel>(&packet->op))
                 {
                     this->number_local_models = 1;
-                    this->src_save = (*packet)->src;
-                    this->original_src_save = (*packet)->original_src;
+                    this->src_save = packet->src;
+                    this->original_src_save = packet->original_src;
                     this->state = AGGREGATING;
                 }
+                break;
             }
-            break;
         case AGGREGATING:
-            // If the aggregating activity has finished (start it if not launched)
-            if (this->aggregate())
             {
-                this->send_global_model_to(this->src_save, this->original_src_save);
-                this->number_local_models = 0;
-                this->state = WAITING_LOCAL_MODELS;
+                this->aggregate();
+
+                if (this->check_end_condition())
+                {
+                    // Stop aggregating and send kills to the trainers
+                    this->send_kills();
+                    this->print_end_report();
+                }
+                else 
+                {
+                    this->send_global_model_to(this->src_save, this->original_src_save);
+                    this->number_local_models = 0;
+                    this->state = WAITING_LOCAL_MODELS;
+                }
+                break;
             }
-            break;
     }
 }
 
 void AsynchronousAggregator::send_global_model_to(node_name dst, node_name final_dst)
 {
-    auto p = Packet(
+    auto p = new Packet(
         dst, final_dst,
         Packet::SendGlobalModel(
             this->number_local_epochs

--- a/simulator/src/node/roles/aggregator/hierarchical_aggregator.cpp
+++ b/simulator/src/node/roles/aggregator/hierarchical_aggregator.cpp
@@ -4,6 +4,7 @@
 #include <xbt/log.h>
 #include "hierarchical_aggregator.hpp"
 #include "../../../utils/utils.hpp"
+#include "../../node.hpp"
 
 using namespace std;
 
@@ -29,94 +30,86 @@ HierarchicalAggregator::HierarchicalAggregator(std::unordered_map<std::string, s
 
 void HierarchicalAggregator::setup_central_nm()
 {
-    auto my_node_name = this->my_node_name;
-
     // Create a new node name to be used for the mailbox that will be receiving and sending to the central aggregator
-    auto new_node_name = format("hierarchical_{}", my_node_name);
+    auto new_node_name = format("hierarchical_{}", this->my_node_name);
 
     // Pretend we are a trainer to be able to register to the central aggregator
     auto my_node_info = NodeInfo { .name = new_node_name, .role = NodeRole::Trainer};
         
-    this->central_nm = make_unique<StarNetworkManager>(my_node_info);
+    auto central_nm = new StarNetworkManager(my_node_info);
 
-    // Set the centra_aggregator_name as bootstrap node so we can register to it when the hierarchical_aggregator is run.
-    this->central_nm->set_bootstrap_nodes(
+    // Set the central_aggregator_name as bootstrap node so we can register to it when the hierarchical_aggregator is run.
+    central_nm->set_bootstrap_nodes(
         new vector<NodeInfo>({ 
             NodeInfo { .name=this->central_aggregator_name, .role=NodeRole::Aggregator } 
         })
     );
 
-    // Creates queues to enable communication between Role and central NM.
-    auto received_packets = make_shared<queue<unique_ptr<Packet>>>();
-    auto to_be_sent_packets = make_shared<queue<shared_ptr<Packet>>>();
-    auto nm_events = make_shared<queue<unique_ptr<Mediator::Event>>>();
-
-    auto central_mc = make_unique<MediatorConsumer>(received_packets, to_be_sent_packets, nm_events);
-    auto central_mp = make_unique<MediatorProducer>(received_packets, to_be_sent_packets, nm_events);
+    auto central_mc = make_unique<MediatorConsumer>(new_node_name);
+    auto central_mp = make_unique<MediatorProducer>(new_node_name);
 
     this->central_mc = std::move(central_mc);
 
-    this->central_nm->set_mediator_producer(std::move(central_mp));
+    central_nm->set_mediator_producer(std::move(central_mp));
+
+    auto e = simgrid::s4u::Engine::get_instance();
+
+    simgrid::s4u::Actor::create(
+        std::format("{}_nm_hierarchical", this->my_node_name), e->host_by_name(this->my_node_name), &Node::run_network_manager, central_nm 
+    );
 }
 
 void HierarchicalAggregator::run()
 {
-    // Run central_nm in parallel, but still check if it ever stops because it will be this network manager 
-    // that receives the kill packet 
-    if(!this->central_nm->run())
-    {
-        this->send_kills();
-        this->print_end_report();
-        this->still_has_activities = false;
-    }
-
-    if (!this->still_has_activities)
-        return;
-
     switch (this->state)
     {
         case INITIALIZING_CENTRAL:
-            // Waiting connection on the central aggregator 
-            if (auto e = this->central_mc->get_nm_event())
             {
+                // Waiting connection on the central aggregator 
+                auto e = this->central_mc->get_nm_event();
+
                 // If type of event is ClusterConnected it means that every node have been connected to us
-                if (auto *conneted_event = get_if<Mediator::NodeConnected>(e->get()))
+                if (auto *conneted_event = get_if<Mediator::NodeConnected>(e.get()))
                 {
                     this->state = INITIALIZING_CLUSTER;
                 }
+
+                break;
             }
-            break;
         case INITIALIZING_CLUSTER:
-            // Waiting connections of the nodes on our own cluster
-            if (auto e = this->mc->get_nm_event())
             {
+                // Waiting connections of the nodes on our own cluster
+                auto e = this->mc->get_nm_event();
+
                 // If type of event is ClusterConnected it means that every node have been connected to us
-                if (auto *conneted_event = get_if<Mediator::ClusterConnected>(e->get()))
+                if (auto *conneted_event = get_if<Mediator::ClusterConnected>(e.get()))
                 {
                     this->number_client_training = conneted_event->number_client_connected;
                     this->state = WAITING_GLOBAL_MODEL;
                 }
+                break;
             }
-            break;
         case WAITING_GLOBAL_MODEL:
-            // Waiting global model from the central aggregator
-            if (auto packet = this->central_mc->get_received_packet())
             {
+                // Waiting global model from the central aggregator
+                auto packet = this->central_mc->get_received_packet();
+
                 // If the operation is a SendGlobalModel
-                if (auto *op_glob = get_if<Packet::SendGlobalModel>(&(*packet)->op))
+                if (auto *op_glob = get_if<Packet::SendGlobalModel>(&packet->op))
                 {
                     this->send_global_model();
                     this->state = WAITING_LOCAL_MODELS;
                 }
                 // Note that the hierarchical aggregator receives kill packet from the central_nm
+                break;
             }
-            break;
         case WAITING_LOCAL_MODELS: 
-            // If a packet have been received
-            if (auto packet = this->mc->get_received_packet())
             {
+                // If a packet have been received
+                auto packet = this->mc->get_received_packet();
+
                 // If the packet's operation is a SendLocalModel
-                if (auto *send_local = get_if<Packet::SendLocalModel>(&(*packet)->op))
+                if (auto *send_local = get_if<Packet::SendLocalModel>(&packet->op))
                 {
                     this->number_local_models += 1;
                     XBT_INFO("nb local models: %lu", this->number_local_models);
@@ -126,12 +119,13 @@ void HierarchicalAggregator::run()
                         this->state = AGGREGATING;
                     }
                 }
+                break;
             }
-            break;
         case AGGREGATING:
-            // If the aggregating activity has finished (start it if not launched)
-            if (this->aggregate())
             {
+                // If the aggregating activity has finished (start it if not launched)
+                this->aggregate();
+
                 this->number_local_models = 0;
                 this->send_model_to_central_aggregator();
                 this->state = WAITING_GLOBAL_MODEL;
@@ -143,7 +137,7 @@ void HierarchicalAggregator::run()
 void HierarchicalAggregator::send_model_to_central_aggregator()
 {
     // Send as if it was a local model (which is the case in theory?).
-    auto p = Packet(
+    auto p = new Packet(
         this->central_aggregator_name, this->central_aggregator_name,
         Packet::SendLocalModel()
     );

--- a/simulator/src/node/roles/aggregator/hierarchical_aggregator.hpp
+++ b/simulator/src/node/roles/aggregator/hierarchical_aggregator.hpp
@@ -26,8 +26,6 @@ private:
 
     node_name central_aggregator_name;
 
-    std::unique_ptr<StarNetworkManager> central_nm;
-
     void send_model_to_central_aggregator();
 
     void setup_central_nm();  

--- a/simulator/src/node/roles/trainer/trainer.cpp
+++ b/simulator/src/node/roles/trainer/trainer.cpp
@@ -77,8 +77,6 @@ void Trainer::run()
                 if (auto *op_glob = get_if<Packet::SendGlobalModel>(&packet->op))
                 {
                     // Get the source to be able to send the local model later
-                    XBT_INFO("src: %s", packet->src.c_str());
-                    XBT_INFO("original_src: %s", packet->original_src.c_str());
                     this->dst = packet->src;
                     this->final_dst = packet->original_src;
 

--- a/simulator/src/node/roles/trainer/trainer.cpp
+++ b/simulator/src/node/roles/trainer/trainer.cpp
@@ -23,65 +23,40 @@ Trainer::Trainer(std::unordered_map<std::string, std::string> *args, node_name n
     delete args;
 }
 
-void Trainer::launch_one_epoch()
+void Trainer::run_one_epoch(uint8_t epoch_index)
 {
     double flops = Constants::LOCAL_MODEL_TRAINING_FLOPS;
 
-    XBT_INFO("Epoch %i ====> ...", this->current_local_epoch);
-    this->current_local_epoch += 1;
+    XBT_INFO("Epoch %i ====> ...", epoch_index);
     
     int nb_core = simgrid::s4u::this_actor::get_host()->get_core_count();
     double nb_flops_per_epoch = flops / nb_core;
 
     XBT_DEBUG("flops / nb_core = nb_flops_per_epoch: %f / %i = %f", flops, nb_core, nb_flops_per_epoch);
     
+    // TODO: maybe actually use simgrid functions to launch in parallel???
     // Launch exactly nb_core parallel tasks
     for (int i = 0; i < nb_core; i++)
     {
         auto exec = simgrid::s4u::this_actor::exec_async(nb_flops_per_epoch);
         this->training_activities->push(exec);
     }
+
+    this->training_activities->wait_all();
 }
 
-bool Trainer::train() 
+void Trainer::train() 
 {
-    // if no activities running
-    if (this->training_activities->empty())
+    for (uint8_t i = 0; i<this->number_local_epochs; i++)
     {
-        this->launch_one_epoch();
+        this->run_one_epoch(i);
     }
-
-    // Test if any activity finished
-    auto activity = this->training_activities->test_any();
-    // XBT_INFO("activity: %p", activity);
-
-    // If the activity isn't nullptr, remove it for the ActivitySet
-    if (activity != nullptr)
-    {
-        // Because the workload is splitted evently between each cores, we know that when one activity finished,
-        // every others have finished too.
-        this->training_activities->clear();
-
-        // if we need to perform more local epoch, start a new epoch task
-        if (this->current_local_epoch < this->number_local_epochs)
-        {
-            this->launch_one_epoch();
-        }
-        else
-        {
-            this->current_local_epoch = 0;
-            // Return true when the last activity have been finished
-            return true;
-        }
-    }
-
-    return false;
 }
 
 void Trainer::send_local_model(node_name dst, node_name final_dst)
 {
     this->mc->put_to_be_sent_packet(
-        Packet(
+        new Packet(
             dst, final_dst,
             Packet::SendLocalModel()
         )
@@ -93,40 +68,41 @@ void Trainer::run()
     switch (this->state)
     {
         case INITIALIZING:
-            // If event available
-            if (auto e = this->mc->get_nm_event())
             {
+                auto e = this->mc->get_nm_event();
+
                 // If type of event is NodeConnected it means that our node is connected :)
-                if (auto *conneted_event = get_if<Mediator::NodeConnected>(e->get()))
+                if (auto *conneted_event = get_if<Mediator::NodeConnected>(e.get()))
                 {
                     this->state = WAITING_GLOBAL_MODEL;
                 }
+                break;
             }
-            break;
         case WAITING_GLOBAL_MODEL:
-            // If packet have been received 
-            if (auto packet = this->mc->get_received_packet())
             {
+                auto packet = this->mc->get_received_packet();
+
                 // If the operation is a SendGlobalModel
-                if (auto *op_glob = get_if<Packet::SendGlobalModel>(&(*packet)->op))
+                if (auto *op_glob = get_if<Packet::SendGlobalModel>(&packet->op))
                 {
                     // Get the source to be able to send the local model later
-                    this->dst = (*packet)->src;
-                    this->final_dst = (*packet)->original_src;
+                    XBT_INFO("src: %s", packet->src.c_str());
+                    XBT_INFO("original_src: %s", packet->original_src.c_str());
+                    this->dst = packet->src;
+                    this->final_dst = packet->original_src;
 
                     // Set the number of local epochs
                     this->number_local_epochs = op_glob->number_local_epochs;
                     this->state = TRAINING;
                 }
+                break;
             }
-            break;
         case TRAINING:
-            // If the training activity has finished (start it if not launched)
-            if (this->train())
             {
+                this->train();
                 this->send_local_model(this->dst, this->final_dst);
                 this->state = WAITING_GLOBAL_MODEL;
+                break;
             }
-            break;
     }
 }

--- a/simulator/src/node/roles/trainer/trainer.hpp
+++ b/simulator/src/node/roles/trainer/trainer.hpp
@@ -27,9 +27,6 @@ protected:
     node_name dst;
     node_name final_dst;
 
-    /** Tracks the current number of local epoch done by the current trainer */
-    uint8_t current_local_epoch = 0;
-
     /** The total number of local epochs to perform */
     uint8_t number_local_epochs = 0;
 
@@ -37,15 +34,14 @@ protected:
     simgrid::s4u::ActivitySet *training_activities;
 
     /**
-     * Launch one trainer epoch in parallel, sharing activities among the Host's cores.
+     * Run and wait one trainer epoch in parallel, sharing activities among the Host's cores.
      */
-    void launch_one_epoch();
+    void run_one_epoch(uint8_t epoch_index);
 
     /** 
-     * Launch the training activity or test if the current one has finished.
-     * @return true if number_local_epochs have been performed, false otherwise.
+     * Run and wait the training activity.
      */
-    bool train();
+    void train();
 
     /** Send the local model to (dst, final_dst) */
     void send_local_model(node_name dst, node_name final_dst);

--- a/simulator/src/node/roles/trainer/trainer.hpp
+++ b/simulator/src/node/roles/trainer/trainer.hpp
@@ -33,13 +33,8 @@ protected:
     /** Simgrid ActivitySet containing the training tasks */
     simgrid::s4u::ActivitySet *training_activities;
 
-    /**
-     * Run and wait one trainer epoch in parallel, sharing activities among the Host's cores.
-     */
-    void run_one_epoch(uint8_t epoch_index);
-
     /** 
-     * Run and wait the training activity.
+     * Run and wait the training activities in parallel.
      */
     void train();
 


### PR DESCRIPTION
Implemented different execution thread to separate Role and NetworkManager
-> They are now running on their respective Actor but still on the same host. For example the Hierarchical NM have 3 actors running on the same host: 1 aggregator role, 2 network managers (one for the cluster network, one for the central network).

The communications between the actors of the same host use the same principle of the previous architecture: they communicate via the Mediator classes, but this time using simgrid MessageQueue instead of C++ queues. This way it is now possible to use passive waiting thus boosting simulation runtime performances.

The automatons (for NM and roles) have remained almost the same, but now they loop less because of passive waiting.